### PR TITLE
Joe/ic connection

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "landing-page/neon"]
 	path = landing-page/neon
 	url = https://github.com/DDMAL/Neon.git
+[submodule "ic"]
+	path = ic
+	url = https://github.com/DDMAL/Standalone-Interactive-Classifier.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,17 +42,41 @@ Schema is migrated forward via `_migrate_db()` in `auth_api.py` — new columns 
 
 ## Running locally
 
-**Both servers must be running simultaneously.**
+**Three servers must be running simultaneously** — the frontend, its backend, and the Interactive Classifier service (the IC step iframes it):
+
+| Port | Process | Role |
+|---|---|---|
+| `5173` | Vite dev server (landing-page) | Open this in the browser; proxies `/api`, `/neon`, `/Neon-gh` → `:8001` |
+| `8001` | landing-page FastAPI (`uvicorn`) | `/api/*`; also reaches IC server-to-server |
+| `8000` | IC service (`ic/` submodule) | IC REST API **and** the built IC SPA (served single-origin) |
+
+### One command (recommended)
 
 ```bash
-# Backend (terminal 1)
-cd landing-page/scripts
-source .venv/bin/activate
+./dev.sh          # starts all three; Ctrl-C tears all three down cleanly
+./dev.sh -b       # rebuild the IC frontend bundle first (do this after the
+                  #   ic/ submodule's frontend changes — else the iframe
+                  #   serves a stale build)
+./dev.sh -f       # free the ports first if something is stuck on them
+./dev.sh -h       # help
+```
+
+Ports are overridable (`WEB_PORT=3000 ./dev.sh`). The script assumes the venvs
+already exist (`ic/api/.venv`, `landing-page/scripts/.venv`) and
+`landing-page/node_modules` is installed — it runs them, it doesn't create them.
+
+### Manual (one terminal each)
+
+```bash
+# Terminal 1 — IC service (:8000)
+cd ic/api && HOST=127.0.0.1 PORT=8000 .venv/bin/ic-api
+
+# Terminal 2 — landing-page backend (:8001)
+cd landing-page/scripts && source .venv/bin/activate
 uvicorn main:app --reload --port 8001
 
-# Frontend (terminal 2)
-cd landing-page
-npm run dev
+# Terminal 3 — landing-page frontend (:5173)
+cd landing-page && npm run dev
 ```
 
 Open `http://localhost:5173`. All `/api/*` calls proxy to the backend automatically.
@@ -61,6 +85,8 @@ Open `http://localhost:5173`. All `/api/*` calls proxy to the backend automatica
 ```
 DATABASE_URL=postgresql://...   # Neon connection string
 MOTHRA_SECRET=...               # JWT signing key
+IC_API_URL=http://localhost:8000    # how :8001 reaches IC (server-to-server)
+IC_PUBLIC_URL=http://localhost:8000 # how the browser/iframe reaches IC's SPA
 ```
 
 ---

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# Mothra local dev launcher — starts all three web-app servers together and
+# tears them all down on Ctrl-C. See CLAUDE.md for the architecture.
+#
+#   :5173  landing-page frontend  (Vite)      — open this in the browser
+#   :8001  landing-page backend   (uvicorn)   — /api/*; proxied from :5173
+#   :8000  Interactive Classifier (ic-api)    — IC REST API + IC SPA (iframe)
+#
+# Usage:
+#   ./dev.sh              start all three
+#   ./dev.sh -b           rebuild the IC frontend bundle first (do this when
+#                         the IC submodule's frontend changed; otherwise the
+#                         iframe serves a stale build — see the binarize bug)
+#   ./dev.sh -f           free the ports first if something is already on them
+#   ./dev.sh -bf          both
+#   ./dev.sh -h           help
+#
+# Ports are overridable: WEB_PORT=3000 ./dev.sh
+set -o pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+WEB_PORT="${WEB_PORT:-5173}"
+API_PORT="${API_PORT:-8001}"
+IC_PORT="${IC_PORT:-8000}"
+
+BUILD_IC=0
+FORCE=0
+
+# --- colours (skipped when not a tty) --------------------------------------
+if [ -t 1 ]; then
+  C_IC=$'\033[36m'; C_API=$'\033[33m'; C_WEB=$'\033[35m'
+  C_OK=$'\033[32m'; C_ERR=$'\033[31m'; C_DIM=$'\033[2m'; C_RST=$'\033[0m'
+else
+  C_IC=''; C_API=''; C_WEB=''; C_OK=''; C_ERR=''; C_DIM=''; C_RST=''
+fi
+
+usage() { sed -n '2,19p' "$0" | sed 's/^# \{0,1\}//'; exit 0; }
+
+while getopts ":bfh" opt; do
+  case "$opt" in
+    b) BUILD_IC=1 ;;
+    f) FORCE=1 ;;
+    h) usage ;;
+    *) echo "unknown flag: -$OPTARG (try -h)" >&2; exit 2 ;;
+  esac
+done
+
+die() { echo "${C_ERR}error:${C_RST} $*" >&2; exit 1; }
+
+port_busy() { lsof -nP -iTCP:"$1" -sTCP:LISTEN >/dev/null 2>&1; }
+
+free_port() {
+  local p=$1 pids
+  pids=$(lsof -nP -tiTCP:"$p" -sTCP:LISTEN 2>/dev/null)
+  [ -n "$pids" ] && kill $pids 2>/dev/null
+}
+
+# --- preflight: required venvs / deps --------------------------------------
+IC_BIN="$ROOT/ic/api/.venv/bin/ic-api"
+API_UVICORN="$ROOT/landing-page/scripts/.venv/bin/uvicorn"
+
+[ -x "$IC_BIN" ]      || die "missing IC venv: $IC_BIN
+  → cd ic/api && uv sync"
+[ -x "$API_UVICORN" ] || die "missing landing-page venv: $API_UVICORN
+  → cd landing-page/scripts && python -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt"
+[ -d "$ROOT/landing-page/node_modules" ] || die "landing-page deps not installed
+  → cd landing-page && npm install"
+[ -f "$ROOT/landing-page/scripts/.env" ] || echo "${C_ERR}warning:${C_RST} landing-page/scripts/.env not found — backend may fail (DATABASE_URL/MOTHRA_SECRET)" >&2
+
+# --- preflight: ports ------------------------------------------------------
+for pair in "web:$WEB_PORT" "backend:$API_PORT" "ic:$IC_PORT"; do
+  name=${pair%%:*}; port=${pair##*:}
+  if port_busy "$port"; then
+    if [ "$FORCE" -eq 1 ]; then
+      echo "${C_DIM}freeing $name port $port…${C_RST}"; free_port "$port"; sleep 1
+    else
+      die "port $port ($name) is already in use. Stop it, or re-run with -f to free it.
+$(lsof -nP -iTCP:"$port" -sTCP:LISTEN | sed 's/^/    /')"
+    fi
+  fi
+done
+
+# --- optional: rebuild the IC frontend bundle the iframe serves ------------
+if [ "$BUILD_IC" -eq 1 ]; then
+  echo "${C_DIM}building IC frontend → ic/api/src/ic_api/static …${C_RST}"
+  npm --prefix "$ROOT/ic/frontend" run build || die "IC frontend build failed"
+  rm -rf "$ROOT/ic/api/src/ic_api/static"
+  cp -r "$ROOT/ic/frontend/dist" "$ROOT/ic/api/src/ic_api/static"
+fi
+
+# --- launch + teardown -----------------------------------------------------
+PIDS=()
+
+# Recursively kill a process and all its descendants (uvicorn --reload spawns
+# a worker child; npm spawns vite — a plain kill on the parent can orphan them).
+kill_tree() {
+  local pid=$1 child
+  for child in $(pgrep -P "$pid" 2>/dev/null); do kill_tree "$child"; done
+  kill "$pid" 2>/dev/null
+}
+
+cleanup() {
+  trap '' INT TERM EXIT          # disarm so this runs once
+  echo; echo "${C_DIM}shutting down…${C_RST}"
+  local pid
+  for pid in "${PIDS[@]}"; do kill_tree "$pid"; done
+  wait 2>/dev/null
+  echo "${C_OK}all stopped.${C_RST}"
+}
+trap cleanup INT TERM EXIT
+
+# start <label> <colour> <cmd...> — prefixes the child's output with a
+# coloured tag; $! is the child's real PID (process-sub leaves it intact).
+start() {
+  local label=$1 colour=$2; shift 2
+  "$@" > >(awk -v p="${colour}[${label}]${C_RST} " '{ print p $0; fflush() }') 2>&1 &
+  PIDS+=($!)
+}
+
+echo "${C_OK}Mothra dev${C_RST}  web:${C_WEB}$WEB_PORT${C_RST}  backend:${C_API}$API_PORT${C_RST}  ic:${C_IC}$IC_PORT${C_RST}   ${C_DIM}(Ctrl-C to stop all)${C_RST}"
+
+start ic  "$C_IC"  env HOST=127.0.0.1 PORT="$IC_PORT" "$IC_BIN"
+start backend "$C_API" "$API_UVICORN" main:app --app-dir "$ROOT/landing-page/scripts" --reload --port "$API_PORT"
+start web "$C_WEB" npm --prefix "$ROOT/landing-page" run dev -- --port "$WEB_PORT" --strictPort
+
+echo "${C_DIM}→ open http://localhost:$WEB_PORT${C_RST}"
+wait

--- a/landing-page/dist/index.html
+++ b/landing-page/dist/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>mothra</title>
-    <script type="module" crossorigin src="/assets/index-B-Rp4_5T.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-D9ApX2wd.css">
+    <script type="module" crossorigin src="/assets/index-CeuKJ584.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-CnegT4eg.css">
   </head>
   <body>
     <div id="root"></div>

--- a/landing-page/scripts/ic_api.py
+++ b/landing-page/scripts/ic_api.py
@@ -1,0 +1,240 @@
+"""Interactive Classifier (IC) bridge.
+
+Connects the mothra workflow to the standalone Interactive Classifier
+vendored at the repo's top-level ``ic/`` submodule and run as its own
+service (default ``http://localhost:8000``).
+
+The flow is server-driven so the GameraXML never has to round-trip
+through the embedded IC iframe:
+
+1. ``POST /api/projects/{id}/ic/start`` — read a project page image from
+   the DB, generate bbox annotations for it, and create an IC session via
+   IC's ``POST /sessions``. Returns the session id plus the deep-link URL
+   the frontend embeds in an iframe (``{IC}/?session=<id>&embed=1``).
+2. ``POST /api/ic/{session_id}/complete`` — call IC's
+   ``POST /sessions/{id}/complete`` and hand the resulting GameraXML back
+   to the frontend, which feeds it into the existing encode flow.
+
+IC is reached over plain HTTP with the stdlib ``urllib`` (no extra
+dependency); calls are server-to-server, so IC's CORS allowlist is
+irrelevant.
+"""
+from __future__ import annotations
+
+import base64
+import io
+import json
+import os
+import urllib.error
+import urllib.request
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from auth_api import get_current_user, get_db_conn
+
+router = APIRouter()
+
+# Where this backend reaches the IC API (server-to-server) and where the
+# browser/iframe reaches the IC SPA. Kept separate so a deployment can
+# point them at different origins; for local dev both are :8000.
+IC_API_URL = os.environ.get("IC_API_URL", "http://localhost:8000").rstrip("/")
+IC_PUBLIC_URL = os.environ.get("IC_PUBLIC_URL", "http://localhost:8000").rstrip("/")
+
+
+# ---------------------------------------------------------------------------
+# Bounding boxes
+# ---------------------------------------------------------------------------
+#
+# IC cannot create a session without a bbox annotation document. Real YOLO
+# inference (POST /api/predict) does not exist in mothra yet, so this is a
+# PLACEHOLDER that lays a coarse grid of boxes over the page just so the
+# embed → classify → encode loop is exercisable end to end. Swap the body
+# of generate_bboxes() for the real detector output (MOTHRA JSON / YOLO TXT)
+# when it lands — nothing else in this module changes.
+
+def generate_bboxes(image_bytes: bytes) -> bytes:
+    """Return a MOTHRA-JSON bbox document (bytes) for ``image_bytes``.
+
+    STUB. Emits a coarse grid of boxes covering the page so a created IC
+    session has glyphs to display. ``classId`` 2 == Neumes (see IC's
+    ``ingest._MOTHRA_CLASS_TO_CATEGORY``). The schema is
+    ``{"annotations": [{"id", "classId", "bbox": [ulx, uly, w, h]}, ...]}``.
+    """
+    try:
+        from PIL import Image  # available in the mothra venv
+
+        with Image.open(io.BytesIO(image_bytes)) as im:
+            page_w, page_h = im.size
+    except Exception:
+        # Fall back to a nominal page size if the image can't be decoded;
+        # the boxes are placeholders regardless.
+        page_w, page_h = 1000, 1400
+
+    cols, rows = 6, 8
+    margin_x = page_w // (cols + 2)
+    margin_y = page_h // (rows + 2)
+    box_w = max(1, page_w // (cols * 2))
+    box_h = max(1, page_h // (rows * 2))
+    step_x = (page_w - 2 * margin_x) // cols
+    step_y = (page_h - 2 * margin_y) // rows
+
+    annotations = []
+    for r in range(rows):
+        for c in range(cols):
+            annotations.append(
+                {
+                    "id": uuid.uuid4().hex,
+                    "classId": 2,  # Neumes
+                    "bbox": [
+                        margin_x + c * step_x,
+                        margin_y + r * step_y,
+                        box_w,
+                        box_h,
+                    ],
+                }
+            )
+    return json.dumps({"annotations": annotations}).encode()
+
+
+# ---------------------------------------------------------------------------
+# Minimal multipart HTTP client (stdlib only)
+# ---------------------------------------------------------------------------
+
+
+def _post_multipart(url: str, fields: dict[str, str], files: list[tuple], timeout: int = 120):
+    """POST ``multipart/form-data`` and return ``(status, body_bytes)``.
+
+    ``files`` is a list of ``(field_name, filename, content_type, data)``.
+    """
+    boundary = uuid.uuid4().hex
+    body = bytearray()
+    for name, value in fields.items():
+        body += f"--{boundary}\r\n".encode()
+        body += f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode()
+        body += value.encode() + b"\r\n"
+    for name, filename, ctype, data in files:
+        body += f"--{boundary}\r\n".encode()
+        body += (
+            f'Content-Disposition: form-data; name="{name}"; '
+            f'filename="{filename}"\r\n'
+        ).encode()
+        body += f"Content-Type: {ctype}\r\n\r\n".encode()
+        body += data + b"\r\n"
+    body += f"--{boundary}--\r\n".encode()
+
+    req = urllib.request.Request(url, data=bytes(body), method="POST")
+    req.add_header("Content-Type", f"multipart/form-data; boundary={boundary}")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.status, resp.read()
+
+
+def _post_empty(url: str, timeout: int = 120):
+    """POST with no body and return ``(status, body_bytes, headers)``."""
+    req = urllib.request.Request(url, data=b"", method="POST")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.status, resp.read(), resp.headers
+
+
+def _ic_unreachable(exc: Exception) -> HTTPException:
+    return HTTPException(
+        status_code=502,
+        detail=f"Interactive Classifier at {IC_API_URL} is unreachable: {exc}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+class IcStartRequest(BaseModel):
+    imageName: str
+
+
+def _project_image(project_id: int, image_name: str, user_id: int) -> tuple[bytes, str]:
+    """Return ``(data, mime_type)`` for a project image the user owns."""
+    con = get_db_conn()
+    cur = con.cursor()
+    try:
+        cur.execute("SELECT user_id FROM projects WHERE id=%s", (project_id,))
+        row = cur.fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail="project not found")
+        if row[0] != user_id:
+            raise HTTPException(status_code=403, detail="not your project")
+        cur.execute(
+            "SELECT data, mime_type FROM project_images WHERE project_id=%s AND name=%s",
+            (project_id, image_name),
+        )
+        img = cur.fetchone()
+        if not img:
+            raise HTTPException(status_code=404, detail="image not found")
+        return bytes(img[0]), (img[1] or "image/png")
+    finally:
+        cur.close()
+        con.close()
+
+
+@router.post("/projects/{project_id}/ic/start")
+def ic_start(project_id: int, body: IcStartRequest, user=Depends(get_current_user)):
+    """Stage one project page + its bboxes in IC and return its deep-link.
+
+    Reads the page image from the DB, generates bbox annotations for it,
+    and *stages* them via IC's ``POST /staging`` — the session itself is
+    created by the user on IC's create-session screen (so they can add
+    training data and pick a vocabulary). Returns the ``?staged=…`` URL the
+    frontend embeds; the created session id comes back via postMessage.
+    """
+    image_bytes, mime_type = _project_image(project_id, body.imageName, user["id"])
+    annotations = generate_bboxes(image_bytes)
+
+    try:
+        status, raw = _post_multipart(
+            f"{IC_API_URL}/staging",
+            fields={"annotations_format": "json"},
+            files=[
+                ("page_image", body.imageName, mime_type, image_bytes),
+                ("annotations", "annotations.json", "application/json", annotations),
+            ],
+        )
+    except urllib.error.URLError as exc:
+        raise _ic_unreachable(exc)
+
+    if status >= 400:
+        raise HTTPException(status_code=502, detail=f"IC /staging failed ({status}): {raw[:500]!r}")
+
+    staging_id = json.loads(raw).get("staging_id")
+    if not staging_id:
+        raise HTTPException(status_code=502, detail="IC /staging returned no staging id")
+
+    return {
+        "staging_id": staging_id,
+        "ic_url": f"{IC_PUBLIC_URL}/?staged={staging_id}&embed=1",
+    }
+
+
+@router.post("/ic/{session_id}/complete")
+def ic_complete(session_id: str, user=Depends(get_current_user)):
+    """Finalise an IC session and return its GameraXML (base64).
+
+    The frontend turns this into a ``File`` and feeds it to the existing
+    ``/api/encode-upload`` flow.
+    """
+    try:
+        status, raw, _headers = _post_empty(f"{IC_API_URL}/sessions/{session_id}/complete")
+    except urllib.error.HTTPError as exc:
+        # IC maps an unknown/torn-down session to 404.
+        raise HTTPException(status_code=exc.code, detail=f"IC complete failed: {exc.read()[:500]!r}")
+    except urllib.error.URLError as exc:
+        raise _ic_unreachable(exc)
+
+    if status >= 400:
+        raise HTTPException(status_code=502, detail=f"IC complete failed ({status})")
+
+    return {
+        "session_id": session_id,
+        "xml_base64": base64.b64encode(raw).decode(),
+        "filename": f"ic-session-{session_id}.xml",
+    }

--- a/landing-page/scripts/main.py
+++ b/landing-page/scripts/main.py
@@ -10,6 +10,7 @@ load_dotenv()
 from auth_api import router as auth_router
 from encode_api import router as encode_router
 from account_api import router as account_router
+from ic_api import router as ic_router
 
 app = FastAPI()
 app.add_middleware(
@@ -21,6 +22,7 @@ app.add_middleware(
 app.include_router(auth_router, prefix="/api")
 app.include_router(encode_router, prefix="/api")
 app.include_router(account_router, prefix="/api")
+app.include_router(ic_router, prefix="/api")
 
 _neon_dir = Path(__file__).parent.parent / "public" / "neon"
 if _neon_dir.exists():

--- a/landing-page/src/components/AppRouter.tsx
+++ b/landing-page/src/components/AppRouter.tsx
@@ -242,7 +242,18 @@ export default function AppRouter({
           images={selectedProject.images.filter((img) =>
             selectedProject.usedImageNames.includes(img.name),
           )}
-          onProcessAll={() => setView("ic-processing")}
+          projectId={selectedProjectId}
+          setPendingXmlFile={setPendingXmlFile}
+          setPendingImageFile={setPendingImageFile}
+          onEncode={() => {
+            if (selectedProjectId && selectedProject) {
+              updateProjectSteps(
+                selectedProjectId,
+                Math.max(selectedProject.stepsUnlocked, 2),
+              );
+            }
+            setView("encoding-processing");
+          }}
         />
       ) : null;
     case "ic-processing":
@@ -280,7 +291,7 @@ export default function AppRouter({
           {...STEP_TIMING}
           singleLabel="processing"
           logs={encodingLogs}
-          onBack={() => setView("ic-completion")}
+          onBack={() => setView("ic")}
           onComplete={() => {
             if (selectedProjectId && selectedProject) {
               updateProjectSteps(

--- a/landing-page/src/components/workflow/InteractiveClassifier.tsx
+++ b/landing-page/src/components/workflow/InteractiveClassifier.tsx
@@ -1,38 +1,132 @@
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { ProjectImage } from "../../types";
+import { authHeaders } from "../../hooks/useAuth";
+import { AuthImage } from "../shared/AuthImage";
 
 interface InteractiveClassifierProps {
   images: ProjectImage[];
-  onProcessAll: () => void;
+  projectId: number | null;
+  setPendingXmlFile: (f: File | null) => void;
+  setPendingImageFile: (f: File | null) => void;
+  // Advance to the encoding step (also unlocks step 2). Called once the
+  // GameraXML + image have been staged via the setters above.
+  onEncode: () => void;
 }
+
+const stemOf = (name: string) => name.replace(/\.[^.]+$/, "");
 
 export default function InteractiveClassifier({
   images,
-  onProcessAll,
+  projectId,
+  setPendingXmlFile,
+  setPendingImageFile,
+  onEncode,
 }: InteractiveClassifierProps) {
   const [currentIdx, setCurrentIdx] = useState(0);
-  const [menuOpen, setMenuOpen] = useState(false);
-  const [processedIds, setProcessedIds] = useState<Set<string>>(new Set());
-
-  const markProcessed = () => {
-    const next = new Set(processedIds);
-    next.add(images[currentIdx].id);
-    setProcessedIds(next);
-    for (let i = currentIdx + 1; i < images.length; i++) {
-      if (!next.has(images[i].id)) {
-        setCurrentIdx(i);
-        return;
-      }
-    }
-    for (let i = 0; i < currentIdx; i++) {
-      if (!next.has(images[i].id)) {
-        setCurrentIdx(i);
-        return;
-      }
-    }
-  };
+  const [icUrl, setIcUrl] = useState<string | null>(null);
+  const [icOrigin, setIcOrigin] = useState<string | null>(null);
+  // Set only once the user finishes IC's create-session screen (the iframe
+  // posts it back); until then there's nothing to encode.
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [status, setStatus] = useState<"idle" | "starting" | "ready" | "error">(
+    "idle",
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [encoding, setEncoding] = useState(false);
 
   const img = images[currentIdx];
+  // Guards against a slow /ic/start response landing after the user has
+  // already switched pages — only the latest request may set state.
+  const startSeq = useRef(0);
+
+  // Stage a fresh page + bboxes in IC whenever the selected page changes.
+  useEffect(() => {
+    if (!img || projectId == null) return;
+    const seq = ++startSeq.current;
+    setStatus("starting");
+    setError(null);
+    setIcUrl(null);
+    setIcOrigin(null);
+    setSessionId(null);
+
+    fetch(`/api/projects/${projectId}/ic/start`, {
+      method: "POST",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ imageName: img.name }),
+    })
+      .then(async (r) => {
+        if (!r.ok) throw new Error(await r.text().catch(() => `HTTP ${r.status}`));
+        return r.json();
+      })
+      .then((data) => {
+        if (seq !== startSeq.current) return; // superseded by a newer page
+        setIcUrl(data.ic_url);
+        try {
+          setIcOrigin(new URL(data.ic_url).origin);
+        } catch {
+          setIcOrigin(null);
+        }
+        setStatus("ready");
+      })
+      .catch((err) => {
+        if (seq !== startSeq.current) return;
+        setError(String(err.message ?? err));
+        setStatus("error");
+      });
+  }, [img?.name, projectId]);
+
+  // The embedded IC posts its new session id once the user starts the
+  // session on the create-session screen. Accept it only from IC's origin.
+  useEffect(() => {
+    function onMessage(e: MessageEvent) {
+      if (icOrigin && e.origin !== icOrigin) return;
+      const data = e.data;
+      if (data?.type === "ic:session-created" && typeof data.sessionId === "string") {
+        setSessionId(data.sessionId);
+      }
+    }
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, [icOrigin]);
+
+  const handleEncode = useCallback(async () => {
+    if (!sessionId || !img) return;
+    setEncoding(true);
+    setError(null);
+    try {
+      // 1. Finalise the IC session → GameraXML.
+      const r = await fetch(`/api/ic/${sessionId}/complete`, {
+        method: "POST",
+        headers: authHeaders(),
+      });
+      if (!r.ok) throw new Error(await r.text().catch(() => `HTTP ${r.status}`));
+      const data = await r.json();
+      const xmlBytes = Uint8Array.from(atob(data.xml_base64), (c) =>
+        c.charCodeAt(0),
+      );
+      const xmlFile = new File([xmlBytes], `${stemOf(img.name)}.xml`, {
+        type: "application/xml",
+      });
+
+      // 2. Fetch the page image bytes so the encoder can read its size.
+      const imgResp = await fetch(`/api/images/${img.id}`, {
+        headers: authHeaders(),
+      });
+      if (!imgResp.ok) throw new Error(`image fetch failed (${imgResp.status})`);
+      const blob = await imgResp.blob();
+      const imageFile = new File([blob], img.name, {
+        type: blob.type || "image/png",
+      });
+
+      // 3. Hand both to the existing encode flow and advance.
+      setPendingXmlFile(xmlFile);
+      setPendingImageFile(imageFile);
+      onEncode();
+    } catch (err) {
+      setError(String((err as Error).message ?? err));
+      setEncoding(false);
+    }
+  }, [sessionId, img, setPendingXmlFile, setPendingImageFile, onEncode]);
 
   // show 5 thumbnails at a time, centered on currentIdx
   const VISIBLE = 5;
@@ -49,89 +143,64 @@ export default function InteractiveClassifier({
         <h1 className="text-4xl font-bold italic text-white">
           interactive classifier
         </h1>
-        <button
-          onClick={onProcessAll}
-          className="px-6 py-2 border-2 border-white text-white rounded-xl hover:opacity-90 cursor-pointer font-semibold"
-        >
-          process all
-        </button>
+        {images.length > 1 && (
+          <span className="text-white/80 text-sm font-mono">
+            page {currentIdx + 1}/{images.length}
+            {img ? ` — ${img.name}` : ""}
+          </span>
+        )}
         <div className="flex-1" />
-        <div className="relative">
-          <button
-            onClick={() => setMenuOpen((o) => !o)}
-            className="w-12 h-12 bg-white rounded-full flex flex-col items-center justify-center gap-1 cursor-pointer hover:opacity-90"
-          >
-            <span className="block w-5 h-0.5 bg-[#1D3335]" />
-            <span className="block w-5 h-0.5 bg-[#1D3335]" />
-            <span className="block w-5 h-0.5 bg-[#1D3335]" />
-          </button>
-          {menuOpen && (
-            <>
-              <div
-                className="fixed inset-0 z-40"
-                onClick={() => setMenuOpen(false)}
-              />
-              <div className="absolute right-0 top-14 z-50 bg-white rounded-2xl shadow-lg p-4 flex flex-col gap-1 min-w-[220px] text-center">
-                <button className="text-[#1D3335] px-4 py-2 hover:opacity-60 cursor-pointer text-sm">
-                  save
-                </button>
-                <button className="text-[#1D3335] px-4 py-2 hover:opacity-60 cursor-pointer text-sm">
-                  about the interactive classifier
-                </button>
-                <button
-                  onClick={() => {
-                    setMenuOpen(false);
-                    onProcessAll();
-                  }}
-                  className="text-[#1D3335] px-4 py-2 hover:opacity-60 cursor-pointer text-sm font-bold"
-                >
-                  process all
-                </button>
-              </div>
-            </>
-          )}
-        </div>
+        {status === "ready" && !sessionId && (
+          <span className="text-white/80 text-sm">
+            start the session in the classifier to enable encoding
+          </span>
+        )}
+        <button
+          onClick={handleEncode}
+          disabled={!sessionId || encoding}
+          className="px-6 py-2 bg-white text-[#1D3335] rounded-xl hover:opacity-90 cursor-pointer font-semibold disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          {encoding ? "encoding…" : "encode"}
+        </button>
       </div>
 
       {/* canvas */}
       <div className="flex-1 bg-[#1D3335] mx-6 rounded-2xl flex flex-col overflow-hidden">
-        {/* image area */}
-        <div className="flex-1 flex items-start justify-start p-6">
+        {/* IC editor area */}
+        <div className="flex-1 flex items-stretch justify-stretch overflow-hidden">
           {images.length === 0 ? (
-            <div className="text-white/40 text-sm italic">
-              {" "}
-              no images selected{" "}
+            <div className="flex-1 flex items-center justify-center text-white/40 text-sm italic">
+              no images selected
             </div>
+          ) : status === "error" ? (
+            <div className="flex-1 flex flex-col items-center justify-center gap-2 text-center px-8">
+              <p className="text-red-300 text-sm">
+                couldn't start the interactive classifier
+              </p>
+              <p className="text-white/50 text-xs font-mono max-w-lg break-words">
+                {error}
+              </p>
+              <p className="text-white/40 text-xs">
+                is the IC service running on its port? (see CLAUDE.md)
+              </p>
+            </div>
+          ) : icUrl ? (
+            <iframe
+              key={icUrl}
+              src={icUrl}
+              title={`Interactive Classifier — ${img?.name ?? ""}`}
+              className="flex-1 w-full border-0"
+            />
           ) : (
-            <div className="w-1/2 aspect-[4/3] bg-[#2A4A4D] rounded-xl overflow-hidden flex items-center justify-center">
-              {img?.src ? (
-                <img
-                  src={img.src}
-                  alt={img.name}
-                  className="w-full h-full object-contain"
-                />
-              ) : (
-                <span className="text-white/50 text-lg">
-                  {img?.name ?? "image"} {currentIdx + 1}/{images.length}
-                </span>
-              )}
+            <div className="flex-1 flex items-center justify-center text-white/50 text-sm">
+              starting classifier…
             </div>
           )}
         </div>
 
-        {/* filmstrip + mark button */}
-
-        {images.length > 0 && (
-          <div className="flex items-center px-6 pb-6 gap-4">
-            <button
-              onClick={markProcessed}
-              disabled={processedIds.has(images[currentIdx].id)}
-              className="px-4 py-2 border-2 border-white text-white text-sm rounded-xl hover:opacity-90 cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed whitespace-nowrap flex-shrink-0"
-            >
-              {processedIds.has(images[currentIdx].id)
-                ? "processed [√]"
-                : "mark image as processed"}
-            </button>
+        {/* filmstrip for page selection */}
+        {images.length > 1 && (
+          <div className="flex items-center px-6 pb-6 pt-4 gap-4">
             <div className="flex-1 flex items-center justify-center gap-3">
               <button
                 onClick={() => setCurrentIdx((i) => i - 1)}
@@ -143,7 +212,6 @@ export default function InteractiveClassifier({
               {visibleImages.map((thumb, i) => {
                 const globalIdx = start + i;
                 const active = globalIdx === currentIdx;
-                const processed = processedIds.has(thumb.id);
                 return (
                   <button
                     key={thumb.id}
@@ -151,22 +219,11 @@ export default function InteractiveClassifier({
                     className={`relative w-16 aspect-square rounded-lg overflow-hidden flex-shrink-0 cursor-pointer transition-all
                       ${active ? "ring-2 ring-white ring-offset-2 ring-offset-[#1D3335]" : "opacity-50 hover:opacity-80"}`}
                   >
-                    {thumb.src ? (
-                      <img
-                        src={thumb.src}
-                        alt={thumb.name}
-                        className="w-full h-full object-cover"
-                      />
-                    ) : (
-                      <div className="w-full h-full bg-[#2A4A4D]" />
-                    )}
-                    {processed && (
-                      <div className="absolute inset-0 bg-black/40 flex items-center justify-center">
-                        <span className="text-white text-lg font-bold">
-                          [√]
-                        </span>
-                      </div>
-                    )}
+                    <AuthImage
+                      src={`/api/images/${thumb.id}`}
+                      alt={thumb.name}
+                      className="w-full h-full object-cover"
+                    />
                   </button>
                 );
               })}


### PR DESCRIPTION
Mount IC into Mothra. 

What changed
Backend — new IC bridge ([landing-page/scripts/ic_api.py](/landing-page/scripts/ic_api.py))

POST /api/projects/{id}/ic/start — reads a project page image from the DB, generates bbox annotations for it, and stages them in IC via POST /staging. Returns the ?staged=… deep-link URL the frontend iframes.
POST /api/ic/{session_id}/complete — finalizes an IC session and returns its GameraXML (base64) for the encode flow.
IC is reached over stdlib urllib (server-to-server, so no extra dependency and IC's CORS allowlist is irrelevant). IC_API_URL / IC_PUBLIC_URL are split so a deployment can point the server hop and the browser hop at different origins.
Router registered in [main.py](vscode-webview://0fm36loic5aesvttrk9781glod26lnrlt5dl83bnkv1r41bh5s5d/landing-page/scripts/main.py).

Frontend — rewrote [InteractiveClassifier.tsx](/landing-page/src/components/workflow/InteractiveClassifier.tsx)

Embeds IC's editor in an iframe per selected page; re-stages on page change (with a startSeq guard so a stale /ic/start response can't clobber a newer page).
Listens for IC's ic:session-created postMessage (origin-checked) to enable the encode button only once the user has actually started a session.
On encode: finalizes the session → builds the .xml + image Files → feeds them to the existing /api/encode-upload flow via setPendingXmlFile/setPendingImageFile, then advances to encoding-processing (unlocking step 2). Wired up in [AppRouter.tsx](vscode-webview://0fm36loic5aesvttrk9781glod26lnrlt5dl83bnkv1r41bh5s5d/landing-page/src/components/AppRouter.tsx).
Filmstrip thumbnails now use <AuthImage>; removed the dead "process all" menu and local "processed" state. Added error/loading states (e.g. IC service unreachable).

Tooling — new [dev.sh](/dev.sh)

Starts all three servers (:5173 web, :8001 backend, :8000 IC) with prefixed/colored output and clean Ctrl-C teardown (recursive kill_tree so uvicorn/vite children aren't orphaned).
Flags: -b rebuild the IC frontend bundle, -f free busy ports, -h help. Ports overridable via env. Preflights venvs/deps and warns on missing .env.

Docs & submodule

[CLAUDE.md](/CLAUDE.md): documented the three-server setup, dev.sh, and the new IC_* env vars.
Bumped ic submodule (3af4de4 → b943a3e) for the staging/embed API adaptations; rebuilt landing-page/dist.
Known limitations / follow-ups
Bbox generation is a placeholder. generate_bboxes() lays a coarse grid of "Neumes" boxes over the page so the embed → classify → encode loop is exercisable end-to-end. Swap its body for real YOLO detector output (POST /api/predict) when that lands — nothing else in the module changes.
One page at a time; no batch.
After rebuilding the IC submodule's frontend, run ./dev.sh -b or the iframe serves a stale build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)