### PR TITLE
Fix IC iframe blocked by proxy X-Frame-Options

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -6,8 +6,14 @@ Celery worker. **Postgres lives in its own repo** (deployed to the `postgres`
 namespace); the app reaches it cross-namespace at
 `mothra-postgres.postgres.svc.cluster.local:5432` via `DATABASE_URL`.
 
-- **Ingress:** Traefik — `mothra.simssa.ca` → backend, `mothra-ic.simssa.ca` → ic.
-  TLS is terminated by the campus proxy; the app is served over https.
+- **Ingress:** Traefik — `mothra.simssa.ca` → backend, `mothra-ic.simssa.ca` → ic
+  (one Ingress object each, see below). TLS is terminated by the campus proxy;
+  the app is served over https.
+- **IC iframe:** the campus proxy injects a blanket `X-Frame-Options: SAMEORIGIN`,
+  which blocks the cross-host IC iframe. A Traefik `Middleware` in `ingress.yaml`
+  adds `Content-Security-Policy: frame-ancestors https://mothra.simssa.ca` to the
+  IC host, which browsers enforce *instead of* XFO. Needs Traefik's CRDs — check
+  the API group with `kubectl get crd | grep middlewares`.
 - **Storage:** static NFS PersistentVolume (RWX) for `stored_models`, shared by
   backend + worker.
 - **Images:** `ghcr.io/ddmal/mothra-{backend,ic,text-service}`, CPU-only, pulled with
@@ -25,7 +31,7 @@ k8s/
   text-service.yaml      # Deployment + Service :8002
   backend.yaml           # Deployment + Service :8001
   worker.yaml            # Deployment (celery worker; no Service)
-  ingress.yaml           # Traefik ingress (both hosts)
+  ingress.yaml           # Traefik: ic-frame-ancestors Middleware + one Ingress per host
 ```
 
 ## First-time setup
@@ -60,6 +66,11 @@ kubectl -n mothra logs deploy/backend | head        # tables created; Celery con
 kubectl -n mothra logs deploy/worker  | head        # "celery ... ready" (threads pool)
 curl -k https://mothra.simssa.ca/                   # SPA HTML
 # smoke test: POST /api/register → authed GET /api/projects (200)
+
+# IC iframe not frame-blocked — expect the frame-ancestors CSP. The proxy's
+# X-Frame-Options: SAMEORIGIN stays in the response; CSP takes precedence.
+curl -sSI https://mothra-ic.simssa.ca/ | grep -iE 'content-security|frame-options'
+kubectl -n mothra describe ingress mothra-ic | grep -i middlewares   # annotation present
 ```
 
 ## Known follow-ups

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -6,6 +6,43 @@
 #
 # Traefik streams responses (no buffering), so the job-progress SSE
 # (GET /api/jobs/{id}/stream) works without extra config.
+#
+# The two hosts are *separate* Ingress objects because the IC host needs a
+# router-scoped middleware (below) that must not apply to the main host —
+# a `router.middlewares` annotation hits every router its Ingress creates.
+# Both objects plus the Middleware live in this one file so the single
+# `kubectl apply -f k8s/ingress.yaml` in .github/workflows/build-images.yml
+# creates the Middleware before the Ingress that references it.
+---
+# Lets mothra.simssa.ca embed the IC SPA in an iframe.
+#
+# The campus front proxy (134.87.11.29, nginx) injects a blanket
+# `X-Frame-Options: SAMEORIGIN` into every response it fronts. mothra-ic is a
+# different host from mothra, so browsers refused the iframe outright
+# ("mothra-ic.simssa.ca refused to connect") even though the IC service itself
+# was healthy. Traefik cannot strip that header — nginx sits *in front* and
+# appends its copy after Traefik is done — but CSP `frame-ancestors` obsoletes
+# X-Frame-Options per the CSP spec: when a response carries both, browsers
+# ignore XFO and enforce frame-ancestors instead. So we add the header we want
+# rather than trying to remove the one we don't. Expect `curl -I` to keep
+# showing the proxy's SAMEORIGIN alongside this CSP — that is working as
+# intended, not a failed override.
+#
+# NOTE: this apiVersion is Traefik v3's API group. On Traefik v2 before 2.11 it
+# is `traefik.containo.us/v1alpha1` instead — confirm against the cluster with
+# `kubectl get crd | grep middlewares` before assuming this applies cleanly.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: ic-frame-ancestors
+  namespace: mothra
+  labels:
+    app: mothra
+spec:
+  headers:
+    customResponseHeaders:
+      Content-Security-Policy: "frame-ancestors https://mothra.simssa.ca"
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -26,6 +63,23 @@ spec:
                 name: backend
                 port:
                   number: 8001
+---
+# The middleware reference format is `<namespace>-<middleware-name>@kubernetescrd`
+# (here: namespace `mothra` + name `ic-frame-ancestors`). A typo fails silently —
+# Traefik serves the route with no middleware attached and the iframe stays
+# blocked — so verify with the curl in k8s/README.md after deploying.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mothra-ic
+  namespace: mothra
+  labels:
+    app: mothra
+  annotations:
+    traefik.ingress.kubernetes.io/router.middlewares: mothra-ic-frame-ancestors@kubernetescrd
+spec:
+  ingressClassName: traefik
+  rules:
     - host: mothra-ic.simssa.ca
       http:
         paths:


### PR DESCRIPTION
## Problem

On https://mothra.simssa.ca the Interactive Classifier iframe fails with
**"mothra-ic.simssa.ca refused to connect"** — even though the IC service is
healthy and serving its SPA:

```
$ curl -sSI https://mothra-ic.simssa.ca/
HTTP/1.1 200 OK
Server: nginx
Referrer-Policy: no-referrer; strict-origin-when-cross-origin
X-Frame-Options: SAMEORIGIN          <-- the blocker
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
```

The campus front proxy (134.87.11.29, nginx) injects a blanket
`X-Frame-Options: SAMEORIGIN` into every response it fronts. `mothra-ic` is a
different host from `mothra`, so browsers refuse the frame outright.

Nothing in this repo sets that header — `rg X-Frame-Options` returns nothing,
`ic/api`'s only middleware is CORS, and our ingress is Traefik, not nginx.

This is invisible in local dev: `:5173` embedding `:8000` is equally
cross-origin, but there's no proxy in front adding the header.

## Fix

Traefik can't strip the header — nginx sits *in front* and appends its copy
after Traefik is done. But CSP `frame-ancestors`
[obsoletes X-Frame-Options](https://www.w3.org/TR/CSP2/#directive-frame-ancestors):
when a response carries both, browsers ignore XFO and enforce `frame-ancestors`
instead. So we add the header we want rather than removing the one we don't.

- New `ic-frame-ancestors` Traefik `Middleware` setting
  `Content-Security-Policy: frame-ancestors https://mothra.simssa.ca`.
- Split the two hosts into one `Ingress` each — a `router.middlewares`
  annotation applies to *every* router its Ingress creates, and the main host
  shouldn't inherit the IC host's framing policy.
- Both objects stay in `ingress.yaml`, so the single
  `kubectl apply -f k8s/ingress.yaml` the `ci-cd` workflow already runs creates
  the Middleware before the Ingress that references it. **No workflow change
  needed.**

Scoped to `frame-ancestors` deliberately: it only governs who may frame IC, and
does not loosen `nosniff`, `Referrer-Policy`, or anything else the proxy sets.

## Before merging

**Confirm the Traefik API group against the cluster:**

```bash
kubectl get crd | grep middlewares
```

This uses Traefik v3's `traefik.io/v1alpha1`. On Traefik v2 before 2.11 it's
`traefik.containo.us/v1alpha1`. A mismatch fails the apply loudly
(`no matches for kind "Middleware"`) under the workflow's `set -euo pipefail`,
aborting the deploy before rollout — better to catch it here than in a red CD
run.

## Verify after deploy

```bash
# expect the frame-ancestors CSP; the proxy's SAMEORIGIN stays in the
# response too, which is fine — CSP takes precedence
curl -sSI https://mothra-ic.simssa.ca/ | grep -iE 'content-security|frame-options'
kubectl -n mothra describe ingress mothra-ic | grep -i middlewares
```

The real confirmation is the iframe rendering in the IC step with no
`Refused to display` line in the DevTools console. A typo'd middleware
reference fails silently — Traefik just serves the route unmodified.

## Deploy note

`mothra-ic.simssa.ca` moves between Ingress objects. Apply order within the file
is Middleware -> `mothra` (drops the IC rule) -> `mothra-ic` (created), so
there's a sub-second window where that host has no route. Harmless, and it's why
the Middleware is ordered first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
