### PR TITLE
various ui requests

### DIFF
--- a/landing-page/scripts/auth_api.py
+++ b/landing-page/scripts/auth_api.py
@@ -555,8 +555,11 @@ def _migrate_db():
     import time as _time
     _now = _time.time()
     for _f in NEON_MANIFESTS_DIR.glob("*.jsonld"):
-        if _now - _f.stat().st_mtime > 86400:
-            _f.unlink(missing_ok=True)
+        try:
+            if _now - _f.stat().st_mtime > 86400:
+                _f.unlink(missing_ok=True)
+        except FileNotFoundError:
+            pass
 _migrate_db()
 
 def _pre_hash(pw: str) -> str:

--- a/landing-page/scripts/auth_api.py
+++ b/landing-page/scripts/auth_api.py
@@ -445,25 +445,14 @@ def _migrate_db():
     con = get_db_conn()
     cur = con.cursor()
     try:
-        cur.execute("ALTER TABLE project_images ADD COLUMN original_width INTEGER")
+        cur.execute("ALTER TABLE project_images ADD COLUMN original_data BYTEA")
         con.commit()
     except psycopg2.errors.DuplicateColumn:
         con.rollback()
     finally:
         cur.close()
         release_db_conn(con)
-
-    con = get_db_conn()
-    cur = con.cursor()
-    try:
-        cur.execute("ALTER TABLE project_images ADD COLUMN original_height INTEGER")
-        con.commit()
-    except psycopg2.errors.DuplicateColumn:
-        con.rollback()
-    finally:
-        cur.close()
-        release_db_conn(con)
-
+        
     # jobs : retry lineage + stored kickoff params (needed by cancel/retry)
     con = get_db_conn(); cur = con.cursor()
     try:

--- a/landing-page/scripts/auth_api.py
+++ b/landing-page/scripts/auth_api.py
@@ -452,6 +452,22 @@ def _migrate_db():
     finally:
         cur.close()
         release_db_conn(con)
+
+    con = get_db_conn()
+    cur = con.cursor()
+    try:
+        # The working-copy `mime_type` column can't be reused for original_data:
+        # a client-side resize (imageResize.ts) always re-encodes the working
+        # copy as JPEG, while original_data keeps whatever format the source
+        # file actually was (PNG, TIFF, ...) — serving/embedding original_data
+        # under the working copy's mime_type mislabels it.
+        cur.execute("ALTER TABLE project_images ADD COLUMN original_mime_type TEXT")
+        con.commit()
+    except psycopg2.errors.DuplicateColumn:
+        con.rollback()
+    finally:
+        cur.close()
+        release_db_conn(con)
         
     # jobs : retry lineage + stored kickoff params (needed by cancel/retry)
     con = get_db_conn(); cur = con.cursor()

--- a/landing-page/scripts/batch_api.py
+++ b/landing-page/scripts/batch_api.py
@@ -32,7 +32,6 @@ from tasks_text_batch import run_text_batch_task
 from auth_api import get_db_conn, get_current_user, release_db_conn, db_cursor, require_project_owner
 from text_api import TEXT_API_URL, _stream_multipart, _music_boxes_for_image, _mask_json_for_image
 from yolo_inference import resolve_yolo_models, write_annotation
-from encode_to_mei import scale_facsimile, get_encoded_dimensions
 
 router = APIRouter()
 
@@ -201,7 +200,7 @@ def cantus_bundle(project_id: int, source_id: str, user=Depends(get_current_user
     with db_cursor() as (con, cur):
         require_project_owner(cur, project_id, user["id"])
         cur.execute("""
-            SELECT m.name, m.xml_content, pi.folio, pi.original_width
+            SELECT m.name, m.xml_content, pi.folio
             FROM mei_files m
             JOIN project_images pi ON pi.project_id = m.project_id AND pi.name = m.image_name
             WHERE m.project_id=%s AND pi.source_id=%s AND m.corrected=1
@@ -222,21 +221,15 @@ def cantus_bundle(project_id: int, source_id: str, user=Depends(get_current_user
         buf = io.BytesIO()
         used_stems, filenames = set(), []
         with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-            for name, xml_content, folio, original_width in rows:
+            for name, xml_content, folio in rows:
                 stem = _sanitize_stem(folio) or _sanitize_stem(name) or "unknown"
                 unique_stem, n = stem, 2
                 while unique_stem in used_stems:
                     unique_stem = f"{stem}-{n}"; n += 1
                 used_stems.add(unique_stem)
                 mei_filename = f"{siglum}_{unique_stem}.mei"
-
-                xml_bytes = xml_content.encode("utf-8")
-                if original_width:
-                    dims = get_encoded_dimensions(xml_bytes)
-                    if dims and dims[0]:
-                        xml_bytes = scale_facsimile(xml_bytes, original_width / dims[0])
                         
-                zf.writestr(mei_filename, xml_bytes)
+                zf.writestr(mei_filename, xml_content)
                 filenames.append(mei_filename)
             zf.writestr("README.txt", _cantus_bundle_readme(source_id, siglum, filenames))
 

--- a/landing-page/scripts/batch_api.py
+++ b/landing-page/scripts/batch_api.py
@@ -225,10 +225,10 @@ def cantus_bundle(project_id: int, source_id: str, user=Depends(get_current_user
                 stem = _sanitize_stem(folio) or _sanitize_stem(name) or "unknown"
                 unique_stem, n = stem, 2
                 while unique_stem in used_stems:
-                    unique_stem = f"{stem}-{n}"; n += 1
+                    unique_stem = f"{stem}-{n}"
+                    n += 1
                 used_stems.add(unique_stem)
                 mei_filename = f"{siglum}_{unique_stem}.mei"
-                        
                 zf.writestr(mei_filename, xml_content)
                 filenames.append(mei_filename)
             zf.writestr("README.txt", _cantus_bundle_readme(source_id, siglum, filenames))

--- a/landing-page/scripts/encode_to_mei.py
+++ b/landing-page/scripts/encode_to_mei.py
@@ -780,18 +780,6 @@ def scale_facsimile(mei_bytes: bytes, factor: float) -> bytes:
     )
     xml_str = xml_declaration + xml_model_pi + ET.tostring(root, encoding="unicode")
     return xml_str.encode("utf-8")
-
-def get_encoded_dimensions(mei_bytes: bytes) -> tuple[int, int] | None:
-    """Read the page width/height (px) this MEI's facsimile was encoded against,
-    from its <surface> element's lrx/lry (surface's ulx/uly are always 0)."""
-    root = ET.fromstring(mei_bytes)
-    surface = root.find(f".//{_tag('surface')}")
-    if surface is None:
-        return None
-    try:
-        return int(surface.get("lrx")), int(surface.get("lry"))
-    except (TypeError, ValueError):
-        return None
     
 REQUIRED_MEI_VERSION = "5.0.0-dev"
 

--- a/landing-page/scripts/images_api.py
+++ b/landing-page/scripts/images_api.py
@@ -57,20 +57,21 @@ async def upload_image(
 
         mime_type = file.content_type or "image/png"
         original_data = psycopg2.Binary(original_bytes) if original_bytes else None
+        original_mime_type = original_file.content_type if (original_file and original_bytes) else None
         if existing:
             cur.execute(
                 "UPDATE project_images SET mime_type=%s, data=%s, folio=%s, source_id=%s, source_name=%s,"
-                " original_data=%s WHERE id=%s",
+                " original_data=%s, original_mime_type=%s WHERE id=%s",
                 (mime_type, psycopg2.Binary(image_bytes), folio or None, source_id or None,
-                 source_name or None, original_data, image_id)
+                 source_name or None, original_data, original_mime_type, image_id)
             )
         else:
             cur.execute(
                 "INSERT INTO project_images (id, project_id, name, mime_type, data, folio, source_id, source_name,"
-                " original_data)"
-                " VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s)",
+                " original_data, original_mime_type)"
+                " VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)",
                 (image_id, project_id, file.filename, mime_type, psycopg2.Binary(image_bytes),
-                 folio or None, source_id or None, source_name or None, original_data)
+                 folio or None, source_id or None, source_name or None, original_data, original_mime_type)
             )
         _log_activity(cur, project_id, "image_imported", file.filename)
         con.commit()
@@ -98,16 +99,20 @@ def get_original_image(image_id: str, user=Depends(get_current_user)):
     (Neon's edit-session bootstrap, the MEI diff view) never need to branch."""
     with db_cursor() as (con, cur):
         cur.execute(
-            "SELECT original_data, data, mime_type FROM project_images WHERE id=%s "
+            "SELECT original_data, original_mime_type, data, mime_type FROM project_images WHERE id=%s "
             " AND project_id IN (SELECT id FROM projects WHERE user_id=%s)",
             (image_id, user["id"]),
         )
         row = cur.fetchone()
     if not row:
         raise HTTPException(status_code=404)
-    original_data, data, mime_type = row
+    original_data, original_mime_type, data, mime_type = row
     image_bytes = original_data if original_data is not None else data
-    return Response(content=bytes(image_bytes), media_type=mime_type or "image/png")
+    # Fall back to the working-copy mime_type for rows written before
+    # original_mime_type existed — best effort, may mislabel pre-migration
+    # originals whose format differs from their resized working copy.
+    resolved_mime_type = (original_mime_type if original_data is not None else mime_type) or mime_type
+    return Response(content=bytes(image_bytes), media_type=resolved_mime_type or "image/png")
 
 @router.get("/images/{image_id}/meta")
 def get_image_meta(image_id: str, user=Depends(get_current_user)):

--- a/landing-page/scripts/images_api.py
+++ b/landing-page/scripts/images_api.py
@@ -20,20 +20,21 @@ async def upload_image(
     folio: Optional[str] = Form(None),
     source_id: Optional[str] = Form(None),
     source_name: Optional[str] = Form(None),
-    original_width: Optional[int] = Form(None),
-    original_height: Optional[int] = Form(None),
+    original_file: Optional[UploadFile] = FAPIFile(None),
     user=Depends(get_current_user),
 ):
     with db_cursor() as (con, cur):
         require_project_owner(cur, project_id, user["id"])
         image_bytes = await file.read()
+        original_bytes = await original_file.read() if original_file else None
 
         # Re-uploading a file with the same name reuses the existing image_id
         # (updates its bytes in place) instead of minting a new row - otherwise
         # annotations/text-alignments tied to the old id are orphaned while a
         # second, independent set accumulates under the new id.
         cur.execute(
-            "SELECT id, octet_length(data) FROM project_images WHERE project_id=%s AND name=%s",
+            "SELECT id, octet_length(data) + COALESCE(octet_length(original_data), 0)"
+            " FROM project_images WHERE project_id=%s AND name=%s",
             (project_id, file.filename),
         )
         existing = cur.fetchone()
@@ -41,33 +42,35 @@ async def upload_image(
         existing_bytes = existing[1] if existing else 0
 
         cur.execute("""
-            SELECT COALESCE(SUM(octet_length(data)), 0)
+            SELECT COALESCE(SUM(octet_length(data) + COALESCE(octet_length(original_data), 0)), 0)
             FROM project_images
             WHERE project_id IN (SELECT id FROM projects WHERE user_id = %s)
         """, (user["id"], ))
         current_bytes = cur.fetchone()[0]
 
-        if current_bytes - existing_bytes + len(image_bytes) > STORAGE_QUOTA_BYTES:
+        new_bytes_len = len(image_bytes) + (len(original_bytes) if original_bytes else 0)
+        if current_bytes - existing_bytes + new_bytes_len > STORAGE_QUOTA_BYTES:
             raise HTTPException(
                 status_code=413,
                 detail=f"Storage quota exceeded ({STORAGE_QUOTA_BYTES // (1024*1024)} MB limit)"
             )
 
         mime_type = file.content_type or "image/png"
+        original_data = psycopg2.Binary(original_bytes) if original_bytes else None
         if existing:
             cur.execute(
                 "UPDATE project_images SET mime_type=%s, data=%s, folio=%s, source_id=%s, source_name=%s,"
-                " original_width=%s, original_height=%s WHERE id=%s",
+                " original_data=%s WHERE id=%s",
                 (mime_type, psycopg2.Binary(image_bytes), folio or None, source_id or None,
-                 source_name or None, original_width, original_height, image_id)
+                 source_name or None, original_data, image_id)
             )
         else:
             cur.execute(
                 "INSERT INTO project_images (id, project_id, name, mime_type, data, folio, source_id, source_name,"
-                " original_width, original_height)"
-                " VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)",
+                " original_data)"
+                " VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s)",
                 (image_id, project_id, file.filename, mime_type, psycopg2.Binary(image_bytes),
-                 folio or None, source_id or None, source_name or None, original_width, original_height)
+                 folio or None, source_id or None, source_name or None, original_data)
             )
         _log_activity(cur, project_id, "image_imported", file.filename)
         con.commit()
@@ -88,6 +91,23 @@ def get_image(image_id: str, user=Depends(get_current_user)):
         raise HTTPException(status_code=404)
     return Response(content=bytes(row[0]), media_type=row[1] or "image/png")
 
+@router.get("/images/{image_id}/original")
+def get_original_image(image_id: str, user=Depends(get_current_user)):
+    """Serves the pre-resize original if one was stored, else falls back to
+    the working copy - always returns a viewable image either way, so callers
+    (Neon's edit-session bootstrap, the MEI diff view) never need to branch."""
+    with db_cursor() as (con, cur):
+        cur.execute(
+            "SELECT original_data, data, mime_type FROM project_images WHERE id=%s "
+            " AND project_id IN (SELECT id FROM projects WHERE user_id=%s)",
+            (image_id, user["id"]),
+        )
+        row = cur.fetchone()
+    if not row:
+        raise HTTPException(status_code=404)
+    original_data, data, mime_type = row
+    image_bytes = original_data if original_data is not None else data
+    return Response(content=bytes(image_bytes), media_type=mime_type or "image/png")
 
 @router.get("/images/{image_id}/meta")
 def get_image_meta(image_id: str, user=Depends(get_current_user)):

--- a/landing-page/scripts/mei_api.py
+++ b/landing-page/scripts/mei_api.py
@@ -118,13 +118,19 @@ def create_edit_session(project_id: int, mei_id: str, user=Depends(get_current_u
 
         image_data_uri = None
         if image_name:
-            cur.execute("SELECT data, original_data, mime_type FROM project_images WHERE project_id=%s AND name=%s",
-                        (project_id, image_name))
+            cur.execute(
+                "SELECT data, original_data, original_mime_type, mime_type FROM project_images"
+                " WHERE project_id=%s AND name=%s",
+                (project_id, image_name))
             img_row = cur.fetchone()
             if img_row:
-                img_data, original_data, mime_type = img_row
+                img_data, original_data, original_mime_type, mime_type = img_row
                 image_bytes = original_data if original_data is not None else img_data
-                mime = mime_type or "image/jpeg"
+                # original_data (when present) can be a different format than
+                # the resized working copy (e.g. PNG vs. the resize's JPEG) —
+                # use its own mime type, falling back to the working copy's
+                # for rows written before original_mime_type existed.
+                mime = (original_mime_type if original_data is not None else mime_type) or mime_type or "image/jpeg"
                 image_data_uri = f"data:{mime};base64,{base64.b64encode(bytes(image_bytes)).decode()}"
 
     edit_token = _make_edit_token(project_id, mei_id)

--- a/landing-page/scripts/mei_api.py
+++ b/landing-page/scripts/mei_api.py
@@ -118,13 +118,14 @@ def create_edit_session(project_id: int, mei_id: str, user=Depends(get_current_u
 
         image_data_uri = None
         if image_name:
-            cur.execute("SELECT data, mime_type FROM project_images WHERE project_id=%s AND name=%s",
+            cur.execute("SELECT data, original_data, mime_type FROM project_images WHERE project_id=%s AND name=%s",
                         (project_id, image_name))
             img_row = cur.fetchone()
             if img_row:
-                img_data, mime_type = img_row
+                img_data, original_data, mime_type = img_row
+                image_bytes = original_data if original_data is not None else img_data
                 mime = mime_type or "image/jpeg"
-                image_data_uri = f"data:{mime};base64,{base64.b64encode(bytes(img_data)).decode()}"
+                image_data_uri = f"data:{mime};base64,{base64.b64encode(bytes(image_bytes)).decode()}"
 
     edit_token = _make_edit_token(project_id, mei_id)
     session_id = _uuid.uuid4().hex[:8]

--- a/landing-page/scripts/tasks_encode.py
+++ b/landing-page/scripts/tasks_encode.py
@@ -1,3 +1,5 @@
+import io
+from PIL import Image
 import base64
 import json
 import mimetypes
@@ -13,8 +15,27 @@ from auth_api import get_db_conn, release_db_conn
 from encode_to_mei import (
     parse_gamera_xml, assign_glyphs_to_staves, estimate_staves_from_glyphs,
     parse_yolo_stave_hints, build_mei, build_neon_manifest, validate_mei,
-    image_dimensions,
+    image_dimensions, scale_facsimile,
 )
+
+def _fetch_original_bytes(project_id: Optional[int], image_name: Optional[str]) -> Optional[bytes]:
+    """Looks up the original (pre-resize) image bytes for (project_id, image_name),
+    if the image was resized at upload time. Returns None if it never was, or
+    project_id/image_name are missing."""
+    if not (project_id and image_name):
+        return None
+    con = get_db_conn()
+    try:
+        cur = con.cursor()
+        cur.execute(
+            "SELECT original_data FROM project_images WHERE project_id=%s AND name=%s",
+            (project_id, image_name),
+        )
+        row = cur.fetchone()
+        cur.close()
+        return bytes(row[0]) if row and row[0] is not None else None
+    finally:
+        release_db_conn(con)
 
 def _resolve_hints(project_id: Optional[int], image_name: Optional[str], page_w, page_h):
     """Looks up saved text-alignment + YOLO stave annotations for one image.
@@ -119,6 +140,12 @@ def _encode_one(publish, xml_bytes, xml_filename, image_bytes, image_filename,
             clef_line=clef_line or 3,
             text_alignment=text_alignment,
         )
+        original_bytes = _fetch_original_bytes(project_id, image_name)
+        if original_bytes and page_w:
+            orig_w, _orig_h = Image.open(io.BytesIO(original_bytes)).size
+            mei_bytes_out = scale_facsimile(mei_bytes_out, orig_w / page_w)
+            ev({"type": "log", "message": f"rescaled facsimile to original image size ({orig_w}px wide)"})
+
         validation_warnings = validate_mei(mei_bytes_out)
         for w in validation_warnings:
             ev({"type": "log", "message": f"[warn] {w}"})

--- a/landing-page/scripts/tasks_encode.py
+++ b/landing-page/scripts/tasks_encode.py
@@ -132,7 +132,7 @@ def _encode_one(publish, xml_bytes, xml_filename, image_bytes, image_filename,
         ev({"type": "stage_done", "name": "validating"})
 
         ev({"type": "stage", "name": "processing"})
-        stem = Path(image_filename).stem if image_filename else Path(xml_filename)
+        stem = Path(image_filename).stem if image_filename else Path(xml_filename).stem
         image_ref = Path(image_filename) if image_filename else Path("")
         mei_bytes_out = build_mei(
             glyphs_by_stave, staves, image_ref, page_w, page_h, stem,
@@ -142,9 +142,13 @@ def _encode_one(publish, xml_bytes, xml_filename, image_bytes, image_filename,
         )
         original_bytes = _fetch_original_bytes(project_id, image_name)
         if original_bytes and page_w:
-            orig_w, _orig_h = Image.open(io.BytesIO(original_bytes)).size
-            mei_bytes_out = scale_facsimile(mei_bytes_out, orig_w / page_w)
-            ev({"type": "log", "message": f"rescaled facsimile to original image size ({orig_w}px wide)"})
+            try:
+                orig_w, _orig_h = Image.open(io.BytesIO(original_bytes)).size
+            except Exception as e:
+                ev({"type": "log", "message": f"[warn] could not decode original image, keeping unscaled facsimile: {e}"})
+            else:
+                mei_bytes_out = scale_facsimile(mei_bytes_out, orig_w / page_w)
+                ev({"type": "log", "message": f"rescaled facsimile to original image size ({orig_w}px wide)"})
 
         validation_warnings = validate_mei(mei_bytes_out)
         for w in validation_warnings:

--- a/landing-page/scripts/tasks_encode.py
+++ b/landing-page/scripts/tasks_encode.py
@@ -132,7 +132,7 @@ def _encode_one(publish, xml_bytes, xml_filename, image_bytes, image_filename,
         ev({"type": "stage_done", "name": "validating"})
 
         ev({"type": "stage", "name": "processing"})
-        stem = Path(xml_filename).stem
+        stem = Path(image_filename).stem if image_filename else Path(xml_filename)
         image_ref = Path(image_filename) if image_filename else Path("")
         mei_bytes_out = build_mei(
             glyphs_by_stave, staves, image_ref, page_w, page_h, stem,

--- a/landing-page/src/components/AppRouter.tsx
+++ b/landing-page/src/components/AppRouter.tsx
@@ -272,14 +272,13 @@ export default function AppRouter({
             updateUsedAnnotationNames(selectedProject.id, names.annotations);
           }}
           stepsUnlocked={selectedProject.stepsUnlocked}
-          onUploadImage={async (file, folio, sourceId, sourceName, originalWidth, originalHeight) => {
+          onUploadImage={async (file, folio, sourceId, sourceName, originalFile) => {
             const form = new FormData();
             form.append("file", file);
             if (folio) form.append("folio", folio);
             if (sourceId) form.append("source_id", sourceId);
             if (sourceName) form.append("source_name", sourceName);
-            if (originalWidth) form.append("original_width", String(originalWidth));
-            if (originalHeight) form.append("original_height", String(originalHeight));
+            if (originalFile) form.append("original_file", originalFile);
             const r = await apiFetchOrThrow(
               `/api/projects/${selectedProject.id}/images`,
               {

--- a/landing-page/src/components/project/AnnotationViewerModal.tsx
+++ b/landing-page/src/components/project/AnnotationViewerModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useCallback, useEffect } from "react";
 import type { AnnotationSet } from "../../types";
 import { apiFetch } from "../../lib/apiFetch";
+import TruncatedName from "../shared/TruncatedName";
 
 interface BBox {
     cls: number;
@@ -104,9 +105,10 @@ export default function AnnotationViewerModal({ set, projectId, onClose }: Props
             <div className="fixed z-50 top-[4.5rem] bottom-4 left-1/2 -translate-x-1/2 w-[calc(100vw-2rem)] max-w-5xl bg-[#C8E6E3] rounded-3xl shadow-2xl flex flex-col overflow-hidden animate-fade-in">
                 {/* header */}
                 <div className="flex items-center gap-4 px-6 py-3 border-b border-[#1D3335]/20 shrink-0">
-                    <p className="font-mono text-sm text-[#1D3335] font-semibold truncate flex-1">
-                        {set.imageName}
-                    </p>
+                    <TruncatedName
+                        name={set.imageName}
+                        className="font-mono text-sm text-[#1D3335] font-semibold flex-1 min-w-0"
+                    />
                     {set.detectionCount !== undefined && (
                         <span className="text-xs text-[#1D3335]/60">
                             {set.detectionCount} detection{set.detectionCount !== 1 ? "s" : ""}

--- a/landing-page/src/components/project/AnnotationsTab.tsx
+++ b/landing-page/src/components/project/AnnotationsTab.tsx
@@ -2,6 +2,7 @@ import { Fragment, useState } from "react";
 import type { AnnotationSet, ProjectImage } from "../../types";
 import { AuthImage } from "../shared/AuthImage";
 import AnnotationViewerModal from "./AnnotationViewerModal";
+import TruncatedName from "../shared/TruncatedName";
 import type { useAssetSection } from "../../hooks/useAssetSection";
 import { sortBySourceThenFolio, sourceGroupLabel } from "../../utils/folio";
 
@@ -127,9 +128,11 @@ export default function AnnotationsTab({
                     </button>
                   </div>
                 </div>
-                <span className="text-sm text-white truncate">
-                  {set.imageName.replace(/\.[^.]+$/, "")}_annotations
-                </span>
+                <TruncatedName
+                  name={set.imageName.replace(/\.[^.]+$/, "")}
+                  suffix="_annotations"
+                  className="text-sm text-white"
+                />
                 {set.detectionCount !== undefined && (
                   <span className="text-xs text-white/50">
                     {set.detectionCount} detection

--- a/landing-page/src/components/project/BatchFolioReviewModal.tsx
+++ b/landing-page/src/components/project/BatchFolioReviewModal.tsx
@@ -1,4 +1,5 @@
 import Modal from "../shared/Modal";
+import TruncatedName from "../shared/TruncatedName";
 import type { FolioReviewRow, FolioReviewStatus } from "../../utils/folio";
 
 interface BatchFolioReviewModalProps {
@@ -51,7 +52,7 @@ export default function BatchFolioReviewModal({
             key={row.fileName}
             className="grid grid-cols-4 gap-2 px-3 py-2 text-xs text-[#1D3335] font-mono items-center"
           >
-            <span className="truncate" title={row.fileName}>{row.fileName}</span>
+            <TruncatedName name={row.fileName} className="min-w-0" />
             <span>{row.positionalFolio ?? "—"}</span>
             <span>{row.detectedFolio ?? "—"}</span>
             <span className={STATUS_COLOR[row.status]}>{STATUS_LABEL[row.status]}</span>

--- a/landing-page/src/components/project/CantusSourcePanel.tsx
+++ b/landing-page/src/components/project/CantusSourcePanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import type { CantusSource, Project, ProjectImage } from "../../types";
 import { apiFetchOrThrow } from "../../lib/apiFetch";
 import type { useTextFindingSettings } from "../../hooks/useTextFindingSettings";
@@ -36,8 +36,13 @@ export default function CantusSourcePanel({
     const [loadedSource, setLoadedSource] = useState<CantusSource | null>(null);
     const [conflict, setConflict] = useState<ProjectImage | null>(null);
     const [exportError, setExportError] = useState<string | null>(null);
+    // Guards against a stale in-flight load committing its (now-outdated)
+    // result after a newer load has already started — e.g. rapidly loading
+    // source A then source B before A's response arrives.
+    const loadRequestRef = useRef(0);
 
     const loadSource = async (id: string, opts: { preserveFolio?: boolean } = {}) => {
+        const requestId = ++loadRequestRef.current;
         const cached = sourceCache.get(id);
         if (cached) {
             setLoadedSource(cached);
@@ -47,6 +52,7 @@ export default function CantusSourcePanel({
             } : { sourceId: cached.sourceId, folio: "" });
             onUpdateSourceId(cached.sourceId);
             setError(null);
+            setLoading(false);
             return;
         }
         setLoading(true);
@@ -55,17 +61,19 @@ export default function CantusSourcePanel({
             const raw: CantusSource = await apiFetchOrThrow(`/api/cantus/source/${id}`).then((r) => r.json());
             const data: CantusSource = {...raw, folios: [...raw.folios].sort(compareFolios) };
             sourceCache.set(id, data);
+            if (requestId !== loadRequestRef.current) return;
             setLoadedSource(data);
             onSourceLoaded?.(data);
             patch(opts.preserveFolio ? { sourceId: data.sourceId } : { sourceId: data.sourceId, folio: "" });
             onUpdateSourceId(data.sourceId);
         } catch (e) {
+            if (requestId !== loadRequestRef.current) return;
             setLoadedSource(null);
             onSourceLoaded?.(null);
             patch({ sourceId: "", folio: "" });
             setError((e as Error).message);
         } finally {
-            setLoading(false);
+            if (requestId === loadRequestRef.current) setLoading(false);
         }
     };
 
@@ -74,12 +82,23 @@ export default function CantusSourcePanel({
         if (trimmed) loadSource(trimmed);
     };
 
+    // textFindingSettings (incl. `folio`) is one application-level state
+    // instance shared across all projects (created once in AppRouter), so
+    // "preserve the folio" is only correct when this effect is re-running for
+    // the *same* project (e.g. a remount after navigating to processing/IC and
+    // back) — otherwise a leftover folio from a different project could leak
+    // into a new project's upload, even when two projects share a source id.
+    const prevProjectIdRef = useRef<number | null>(null);
+
     useEffect(() => {
         // project switched — clear all per-project Cantus/OCR state, then
         // load the newly-selected project's own saved source (if any). Keyed on
-        // project.id (not project.cantusSourceId) so this fires on every switch,
-        // including between two projects that happen to share a source id or
-        // both have none.
+        // project.id (not just project.cantusSourceId) so this fires on every
+        // switch, including between two projects that happen to share a source
+        // id or both have none.
+        const isSameProject = prevProjectIdRef.current === project.id;
+        prevProjectIdRef.current = project.id;
+
         setLoadedSource(null);
         setError(null);
         setConflict(null);
@@ -89,13 +108,13 @@ export default function CantusSourcePanel({
 
         if (project.cantusSourceId) {
             setSourceIdInput(project.cantusSourceId);
-            loadSource(project.cantusSourceId, { preserveFolio: true });
+            loadSource(project.cantusSourceId, { preserveFolio: isSameProject });
         } else {
             setSourceIdInput("");
             patch({ sourceId: "", folio: ""});
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [project.cantusSourceId]);
+    }, [project.id, project.cantusSourceId]);
 
     return (
         <div className="mb-4 bg-white/10 rounded-xl p-4 flex flex-col gap-3 text-sm text-white max-w-xl">

--- a/landing-page/src/components/project/CantusSourcePanel.tsx
+++ b/landing-page/src/components/project/CantusSourcePanel.tsx
@@ -5,6 +5,11 @@ import type { useTextFindingSettings } from "../../hooks/useTextFindingSettings"
 import { findFolioConflict, compareFolios } from "../../utils/folio";
 import { downloadBlob } from "../../utils/download";
 
+// Persists across CantusSourcePanel unmount/remount (e.g. navigating to the
+// processing/IC view and back) so a slow or failed background revalidation
+// never has to hide a source that was already loaded once this session.
+const sourceCache = new Map<string, CantusSource>();
+
 interface CantusSourcePanelProps {
     textFindingSettings: ReturnType<typeof useTextFindingSettings>;
     project: Project,
@@ -16,13 +21,12 @@ interface CantusSourcePanelProps {
     onBatchStartFolioChange: (folio: string) => void;
     onBatchEndFolioChange: (folio: string) => void;
     batchFolioSequence: string[];
-    locked: boolean;
 }
 
 export default function CantusSourcePanel({
     textFindingSettings, project, onUpdateSourceId, onSourceLoaded,
     imageSubTab, batchStartFolio, batchEndFolio, onBatchStartFolioChange, onBatchEndFolioChange,
-    batchFolioSequence, locked,
+    batchFolioSequence,
 }: CantusSourcePanelProps) {
     const { ocrOnlyMode, sourceId, folio, patch } = textFindingSettings;
     const [sourceIdInput, setSourceIdInput] = useState(sourceId);
@@ -32,15 +36,27 @@ export default function CantusSourcePanel({
     const [conflict, setConflict] = useState<ProjectImage | null>(null);
     const [exportError, setExportError] = useState<string | null>(null);
 
-    const loadSource = async (id: string) => {
+    const loadSource = async (id: string, opts: { preserveFolio?: boolean } = {}) => {
+        const cached = sourceCache.get(id);
+        if (cached) {
+            setLoadedSource(cached);
+            onSourceLoaded?.(cached);
+            patch(opts.preserveFolio ? {
+                sourceId: cached.sourceId
+            } : { sourceId: cached.sourceId, folio: "" });
+            onUpdateSourceId(cached.sourceId);
+            setError(null);
+            return;
+        }
         setLoading(true);
         setError(null);
         try {
             const raw: CantusSource = await apiFetchOrThrow(`/api/cantus/source/${id}`).then((r) => r.json());
             const data: CantusSource = {...raw, folios: [...raw.folios].sort(compareFolios) };
+            sourceCache.set(id, data);
             setLoadedSource(data);
             onSourceLoaded?.(data);
-            patch({ sourceId: data.sourceId, folio: ""});
+            patch(opts.preserveFolio ? { sourceId: data.sourceId } : { sourceId: data.sourceId, folio: "" });
             onUpdateSourceId(data.sourceId);
         } catch (e) {
             setLoadedSource(null);
@@ -72,7 +88,7 @@ export default function CantusSourcePanel({
 
         if (project.cantusSourceId) {
             setSourceIdInput(project.cantusSourceId);
-            loadSource(project.cantusSourceId);
+            loadSource(project.cantusSourceId, { preserveFolio: true });
         } else {
             setSourceIdInput("");
             patch({ sourceId: "", folio: ""});
@@ -100,23 +116,17 @@ export default function CantusSourcePanel({
                 value={sourceIdInput}
                 onChange={(e) => setSourceIdInput(e.target.value)}
                 placeholder="CantusDB source ID"
-                disabled={locked}
                 className="bg-[#1D3335] border border-white/30 rounded px-2 py-1 text-sm text-white outline-none w-40"
                 />
                 <button
                 onClick={handleLoad}
-                disabled={loading || !sourceIdInput.trim() || locked || sourceIdInput.trim() === loadedSource?.sourceId}
+                disabled={loading || !sourceIdInput.trim() || sourceIdInput.trim() === loadedSource?.sourceId}
                 className="px-3 py-1 border border-white/40 text-white text-xs rounded-lg hover:opacity-90 cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
                 >
                 {loading ? "loading..." : "load"}
                 </button>
             </div>
-            {locked ? (
-                <p className="text-white/50 text-xs w-fit">
-                    source is locked - this project has already moved past the upload step
-                </p>
-            ) : (
-                <a
+            <a
                 href="https://cantusdatabase.org/sources/"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -124,7 +134,6 @@ export default function CantusSourcePanel({
             >
                 don't know your source ID?
             </a>
-            )}
             {error && <p className="text-red-200 text-xs">{error}</p>}
             {loadedSource && (
                 <div className="flex flex-col gap-2">

--- a/landing-page/src/components/project/CantusSourcePanel.tsx
+++ b/landing-page/src/components/project/CantusSourcePanel.tsx
@@ -110,6 +110,10 @@ export default function CantusSourcePanel({
             setSourceIdInput(project.cantusSourceId);
             loadSource(project.cantusSourceId, { preserveFolio: isSameProject });
         } else {
+            // invalidate any still-in-flight load from a previous project so
+            // its (now-stale) response can't land here and set a source that
+            // this project never had
+            loadRequestRef.current++;
             setSourceIdInput("");
             patch({ sourceId: "", folio: ""});
         }

--- a/landing-page/src/components/project/CantusSourcePanel.tsx
+++ b/landing-page/src/components/project/CantusSourcePanel.tsx
@@ -21,12 +21,13 @@ interface CantusSourcePanelProps {
     onBatchStartFolioChange: (folio: string) => void;
     onBatchEndFolioChange: (folio: string) => void;
     batchFolioSequence: string[];
+    locked: boolean;
 }
 
 export default function CantusSourcePanel({
     textFindingSettings, project, onUpdateSourceId, onSourceLoaded,
     imageSubTab, batchStartFolio, batchEndFolio, onBatchStartFolioChange, onBatchEndFolioChange,
-    batchFolioSequence,
+    batchFolioSequence, locked,
 }: CantusSourcePanelProps) {
     const { ocrOnlyMode, sourceId, folio, patch } = textFindingSettings;
     const [sourceIdInput, setSourceIdInput] = useState(sourceId);
@@ -116,17 +117,23 @@ export default function CantusSourcePanel({
                 value={sourceIdInput}
                 onChange={(e) => setSourceIdInput(e.target.value)}
                 placeholder="CantusDB source ID"
+                disabled={locked}
                 className="bg-[#1D3335] border border-white/30 rounded px-2 py-1 text-sm text-white outline-none w-40"
                 />
                 <button
                 onClick={handleLoad}
-                disabled={loading || !sourceIdInput.trim() || sourceIdInput.trim() === loadedSource?.sourceId}
+                disabled={loading || !sourceIdInput.trim() || locked || sourceIdInput.trim() === loadedSource?.sourceId}
                 className="px-3 py-1 border border-white/40 text-white text-xs rounded-lg hover:opacity-90 cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
                 >
                 {loading ? "loading..." : "load"}
                 </button>
             </div>
-            <a
+            {locked ? (
+                <p className="text-white/50 text-xs w-fit">
+                    source is locked - this project has already moved past the upload step
+                </p>
+            ) : (
+                <a
                 href="https://cantusdatabase.org/sources/"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -134,6 +141,7 @@ export default function CantusSourcePanel({
             >
                 don't know your source ID?
             </a>
+            )}
             {error && <p className="text-red-200 text-xs">{error}</p>}
             {loadedSource && (
                 <div className="flex flex-col gap-2">

--- a/landing-page/src/components/project/ImageTab.tsx
+++ b/landing-page/src/components/project/ImageTab.tsx
@@ -12,6 +12,7 @@ import Modal from "../shared/Modal";
 import LargeImageWarningModal from "./LargeImageWarningModal";
 import ContextMenu from "../shared/ContextMenu";
 import AssetGrid from "../shared/AssetGrid";
+import TruncatedName from "../shared/TruncatedName";
 import RenameModal from "./RenameModal";
 import QuickLookModal from "../shared/QuickLookModal";
 import FileDropZone from "../shared/FileDropZone";
@@ -744,7 +745,7 @@ export default function ImageTab({
                 <div className="flex flex-col gap-2 text-sm text-white/70 font-mono">
                   <div className="flex justify-between gap-4">
                     <span>name</span>
-                    <span className="text-white truncate">{img.name}</span>
+                    <TruncatedName name={img.name} className="text-white" />
                   </div>
                   {img.folio && (
                     <span className="absolute top-1 right-1 bg-[#1D3335]/80 text-white text-[10px] font-mono px-1.5 py-0.5 rounded">

--- a/landing-page/src/components/project/ImageTab.tsx
+++ b/landing-page/src/components/project/ImageTab.tsx
@@ -598,6 +598,7 @@ export default function ImageTab({
                 onUsedNamesChange({
                   ...usedNames, images: [...usedNames.images, img.name],
                 });
+                setValidationError(null);
               }
             }}
           />
@@ -748,7 +749,7 @@ export default function ImageTab({
                     <TruncatedName name={img.name} className="text-white" />
                   </div>
                   {img.folio && (
-                    <span className="absolute top-1 right-1 bg-[#1D3335]/80 text-white text-[10px] font-mono px-1.5 py-0.5 rounded">
+                    <span className="self-end bg-[#1D3335]/80 text-white text-[10px] font-mono px-1.5 py-0.5 rounded">
                       {img.folio}
                     </span>
                   )}

--- a/landing-page/src/components/project/ImageTab.tsx
+++ b/landing-page/src/components/project/ImageTab.tsx
@@ -592,6 +592,13 @@ export default function ImageTab({
             getItemBadge={(name) =>
               getImageProgress(name, project.annotations ?? [], project.meiFiles ?? [], project.stepsUnlocked)?.badge ?? null
             }
+            onUse={(img) => {
+              if (!usedNames.images.includes(img.name)) {
+                onUsedNamesChange({
+                  ...usedNames, images: [...usedNames.images, img.name],
+                });
+              }
+            }}
           />
         )}
       </div>
@@ -740,10 +747,9 @@ export default function ImageTab({
                     <span className="text-white truncate">{img.name}</span>
                   </div>
                   {img.folio && (
-                    <div className="flex justify-between gap-4">
-                      <span>folio</span>
-                      <span className="text-white">{img.folio}</span>
-                    </div>
+                    <span className="absolute top-1 right-1 bg-[#1D3335]/80 text-white text-[10px] font-mono px-1.5 py-0.5 rounded">
+                      {img.folio}
+                    </span>
                   )}
                   <div className="flex justify-between gap-4">
                     <span>type</span>

--- a/landing-page/src/components/project/ImageTab.tsx
+++ b/landing-page/src/components/project/ImageTab.tsx
@@ -40,8 +40,7 @@ interface ImageTabProps {
     folio?: string,
     sourceId?: string,
     sourceName?: string,
-    originalWidth?: number,
-    originalHeight?: number,
+    originalFile?: File,
   ) => Promise<{ id: string; name: string; folio?: string; sourceId?: string; sourceName?: string }>;
   onDeleteImage: (imageId: string) => Promise<void>;
   setValidationError: (e: string | null) => void;
@@ -222,8 +221,7 @@ export default function ImageTab({
 
   interface PendingUpload {
     file: File;
-    originalWidth?: number;
-    originalHeight?: number;
+    originalFile?: File;
   }
 
   const computeFolioReviewRows = (imageFiles: File[]): FolioReviewRow[] => {
@@ -274,7 +272,7 @@ export default function ImageTab({
       let done = 0;
 
       const imageEntries = await Promise.all(
-        imageUploads.map(async ({ file: f, originalWidth, originalHeight }) => {
+        imageUploads.map(async ({ file: f, originalFile }) => {
           const folio = folioOverride?.get(f.name) ?? folioAt(seq++);
           // only associate with the loaded Cantus source when this upload is
           // actually being tagged with a folio - otherwise a source loaded
@@ -283,7 +281,7 @@ export default function ImageTab({
           // on mount regardless of which sub-tab is active).
           const result = await onUploadImage(
             f, folio, folio ? cantusSourceId : undefined, folio ? cantusSourceName : undefined,
-            originalWidth, originalHeight,
+            originalFile,
           );
           done++;
           setUploadProgress({ done, total });
@@ -302,11 +300,11 @@ export default function ImageTab({
       );
 
       const pdfEntries = await Promise.all(
-        pdfUploads.map(async ({ file: f, originalWidth, originalHeight }) => {
+        pdfUploads.map(async ({ file: f, originalFile }) => {
           const pdfFolio = folioAt(seq++);
           const result = await onUploadImage(
             f, pdfFolio, pdfFolio ? cantusSourceId : undefined, pdfFolio ? cantusSourceName : undefined,
-            originalWidth, originalHeight,
+            originalFile,
           );
           done++;
           setUploadProgress({ done, total });
@@ -431,12 +429,8 @@ export default function ImageTab({
     const oversizedSet = new Set(oversized);
     const toPendingUpload = async (f: File): Promise<PendingUpload> => {
       if (!oversizedSet.has(f)) return { file: f };
-      const resized = await resizeImageFile(f, TARGET_RESIZE_BYTES);
-      return {
-        file: resized.file,
-        originalWidth: resized.originalWidth,
-        originalHeight: resized.originalHeight,
-      };
+      const resizedFile = await resizeImageFile(f, TARGET_RESIZE_BYTES);
+      return { file: resizedFile, originalFile: f };
     };
     const [imageUploads, pdfUploads] = await Promise.all([
       Promise.all(imageFiles.map(toPendingUpload)),

--- a/landing-page/src/components/project/LargeImageWarningModal.tsx
+++ b/landing-page/src/components/project/LargeImageWarningModal.tsx
@@ -1,4 +1,5 @@
 import Modal from "../shared/Modal";
+import TruncatedName from "../shared/TruncatedName";
 
 interface LargeImageWarningModalProps {
     oversizedFiles: File[];
@@ -46,9 +47,7 @@ export default function LargeImageWarningModal({
                 key={`${f.name}-${i}`}
                 className="grid grid-cols-2 gap-2 px-3 py-2 text-xs text-[#1D3335] font-mono items-center"
             >
-                <span className="truncate" title={f.name}>
-                {f.name}
-                </span>
+                <TruncatedName name={f.name} className="min-w-0" />
                 <span>{formatBytes(f.size)}</span>
             </div>
             ))}

--- a/landing-page/src/components/project/MeiTab.tsx
+++ b/landing-page/src/components/project/MeiTab.tsx
@@ -219,6 +219,13 @@ export default function MeiTab({
           );
         })()}
 
+      {meiViewFile && (
+        <MeiViewerModal
+          file={meiViewFile}
+          onClose={() => setMeiViewFile(null)}
+        />
+      )}
+
       {validateModal && (
         <Modal onClose={() => setValidateModal(null)}>
           <h2 className="text-xl text-[#1D3335] text-center">

--- a/landing-page/src/components/project/MeiTab.tsx
+++ b/landing-page/src/components/project/MeiTab.tsx
@@ -219,13 +219,6 @@ export default function MeiTab({
           );
         })()}
 
-      {meiViewFile && (
-        <MeiViewerModal
-          file={meiViewFile}
-          project={project}
-          onClose={() => setMeiViewFile(null)}
-        />
-      )}
       {validateModal && (
         <Modal onClose={() => setValidateModal(null)}>
           <h2 className="text-xl text-[#1D3335] text-center">

--- a/landing-page/src/components/project/MeiViewerModal.tsx
+++ b/landing-page/src/components/project/MeiViewerModal.tsx
@@ -1,4 +1,3 @@
-import { useState, useRef, useCallback, useEffect } from "react";
 import type { MeiFile } from "../../types";
 import { downloadBlob } from "../../utils/download";
 
@@ -8,14 +7,12 @@ interface Props {
 }
 
 export default function MeiViewerModal({ file, onClose }: Props) {
-
     const handleExport = () => {
         downloadBlob(
             new Blob([file.xmlContent ?? ""], { type: "application/xml" }),
             file.name,
         );
     }
-
 
     return (
         <>

--- a/landing-page/src/components/project/MeiViewerModal.tsx
+++ b/landing-page/src/components/project/MeiViewerModal.tsx
@@ -1,64 +1,13 @@
 import { useState, useRef, useCallback, useEffect } from "react";
-import type { Project, MeiFile } from "../../types";
-import { apiFetch } from "../../lib/apiFetch";
+import type { MeiFile } from "../../types";
 import { downloadBlob } from "../../utils/download";
-
-type Tab = "text" | "score";
-
-interface Zone {
-    id: string;
-    zoneType: "staff" | "other";
-    ulx: number;
-    uly: number;
-    lrx: number;
-    lry: number;
-}
-
-type ScoreState = 
-    | { status: "idle" }
-    | { status: "loading" }
-    | { status: "error"; message: string }
-    | { status: "ready"; imageUrl: string; zones: Zone[]; surfaceW: number; surfaceH: number };
-
-function parseMeiZones(
-    xml: string,
-): { zones: Zone[]; surfaceW: number; surfaceH: number } | null {
-    try {
-        const doc = new DOMParser().parseFromString(xml, "application/xml");
-        const surface = doc.querySelector("surface");
-        if (!surface) return null;
-        const surfaceW = parseInt(surface.getAttribute("lrx") ?? "0");
-        const surfaceH = parseInt(surface.getAttribute("lry") ?? "0");
-        if (!surfaceW || !surfaceH) return null;
-        const zones: Zone[] = [];
-        surface.querySelectorAll("zone").forEach((el) => {
-            zones.push({
-                id: el.getAttribute("xml:id") ?? "",
-                zoneType: el.getAttribute("type") === "staff" ? "staff" : "other",
-                ulx: parseInt(el.getAttribute("ulx") ?? "0"),
-                uly: parseInt(el.getAttribute("uly") ?? "0"),
-                lrx: parseInt(el.getAttribute("lrx") ?? "0"),
-                lry: parseInt(el.getAttribute("lry") ?? "0"),
-            });
-        });
-        return { zones, surfaceW, surfaceH };
-    } catch {
-        return null;
-    }
-}
 
 interface Props {
     file: MeiFile;
-    project: Project;
     onClose: () => void;
 }
 
-export default function MeiViewerModal({ file, project, onClose }: Props) {
-    const [tab, setTab] = useState<Tab>("text");
-    const [scoreState, setScoreState] = useState<ScoreState>({ status: "idle" });
-    const fetched = useRef(false);
-    const canvasRef = useRef<HTMLCanvasElement>(null);
-    const imgRef = useRef<HTMLImageElement>(null);
+export default function MeiViewerModal({ file, onClose }: Props) {
 
     const handleExport = () => {
         downloadBlob(
@@ -67,78 +16,6 @@ export default function MeiViewerModal({ file, project, onClose }: Props) {
         );
     }
 
-    const drawOverlay = useCallback(() => {
-        if (scoreState.status !== "ready") return;
-        const canvas = canvasRef.current;
-        const img = imgRef.current;
-        if (!canvas || !img) return;
-        const { zones, surfaceW, surfaceH } = scoreState;
-        const dw = img.clientWidth;
-        const dh = img.clientHeight;
-        canvas.width = dw;
-        canvas.height = dh;
-        const ctx = canvas.getContext("2d")!;
-        ctx.clearRect(0, 0, dw, dh);
-        const sx = dw / surfaceW;
-        const sy = dh / surfaceH;
-        zones.forEach((zone) => {
-            const isStaff = zone.zoneType === "staff";
-            ctx.fillStyle = isStaff ? "rgba(74,173,170,0.12)" : "rgba(255,165,0,0.12)";
-            ctx.strokeStyle = isStaff ? "#4AADAA" : "#FFA500";
-            ctx.lineWidth = isStaff ? 2 : 1;
-            const x = zone.ulx * sx;
-            const y = zone.uly * sy;
-            const w = (zone.lrx - zone.ulx) * sx;
-            const h = (zone.lry - zone.uly) * sy;
-            ctx.fillRect(x, y, w, h);
-            ctx.strokeRect(x, y, w, h);
-        });
-    }, [scoreState]);
-
-    useEffect(() => {
-        if (scoreState.status === "ready" && imgRef.current?.complete) {
-            drawOverlay();
-        }
-    }, [scoreState.status, drawOverlay]);
-
-    useEffect(() => {
-        return () => {
-            if (scoreState.status === "ready") URL.revokeObjectURL(scoreState.imageUrl);
-        };
-    }, [scoreState]);
-
-    const openScoreTab = () => {
-        setTab("score");
-        if (fetched.current) return;
-        fetched.current = true;
-
-        if (!file.imageName) {
-            setScoreState({ status: "error", message: "No image is associated with this MEI file." });
-            return;
-        }
-        if (!file.xmlContent) {
-            setScoreState({ status: "error", message: "MEI file has no content."});
-            return;
-        }
-        const parsed = parseMeiZones(file.xmlContent);
-        if (!parsed) {
-            setScoreState({ status: "error", message: "Could not parse zone coordinates from MEI." });
-            return;
-        }
-        const imgRecord = project.images.find((i) => i.name === file.imageName);
-        if (!imgRecord) {
-            setScoreState({ status: "error", message: "Associated image not found in project." });
-            return;
-        }
-        setScoreState({ status: "loading" });
-        apiFetch(`/api/images/${imgRecord.id}`)
-            .then((r) => (r.ok ? r.blob() : Promise.reject()))
-            .then((blob) => {
-                const url = URL.createObjectURL(blob);
-                setScoreState({ status: "ready", imageUrl: url, ...parsed });
-            })
-            .catch(() => setScoreState({ status: "error", message: "Failed to load score view." }));
-    };
 
     return (
         <>
@@ -149,28 +26,6 @@ export default function MeiViewerModal({ file, project, onClose }: Props) {
                 <p className="font-mono text-sm text-[#1D3335] font-semibold truncate flex-1">
                     {file.name}
                 </p>
-                <div className="flex gap-1 bg-white/40 rounded-xl p-1">
-                    <button
-                    onClick={() => setTab("text")}
-                    className={`px-4 py-1 rounded-lg text-sm font-semibold transition-colors cursor-pointer ${
-                        tab === "text"
-                        ? "bg-white text-[#4AADAA]"
-                        : "text-[#1D3335]/60 hover:text-[#1D3335]"
-                    }`}
-                    >
-                    Text
-                    </button>
-                    <button
-                    onClick={openScoreTab}
-                    className={`px-4 py-1 rounded-lg text-sm font-semibold transition-colors cursor-pointer ${
-                        tab === "score"
-                        ? "bg-white text-[#4AADAA]"
-                        : "text-[#1D3335]/60 hover:text-[#1D3335]"
-                    }`}
-                    >
-                    Score
-                    </button>
-                </div>
                 <button
                     onClick={handleExport}
                     className="px-4 py-1.5 bg-white text-[#1D3335] font-semibold rounded-xl hover:opacity-90 cursor-pointer text-sm"
@@ -186,38 +41,15 @@ export default function MeiViewerModal({ file, project, onClose }: Props) {
                 </div>
 
                 {/* content */}
-                <div className="flex-1 min-h-0 overflow-auto">
-                {tab === "text" ? (
-                    <pre className="text-[#1D3335]/80 text-xs font-mono h-full whitespace-pre-wrap p-6">
+                <div className="flex-1 min-h-0 overflow-auto p-6">
+                <p className="text-[#1D3335]/60 text-xs mb-3 italic">
+                    Proceed to correction to visualize and correct this file.
+                </p>
+                <pre className="text-[#1D3335]/80 text-xs font-mono whitespace-pre-wrap">
                     {file.xmlContent ?? "(no content)"}
-                    </pre>
-                ) : scoreState.status === "loading" ? (
-                    <div className="flex items-center justify-center h-full text-[#1D3335]/60 text-sm">
-                    loading…
-                    </div>
-                ) : scoreState.status === "error" ? (
-                    <div className="flex items-center justify-center h-full text-[#1D3335]/60 text-sm">
-                    {scoreState.message}
-                    </div>
-                ) : scoreState.status === "ready" ? (
-                    <div className="p-4 flex justify-center">
-                    <div className="relative inline-block">
-                        <img
-                        ref={imgRef}
-                        src={scoreState.imageUrl}
-                        alt={file.imageName ?? "manuscript"}
-                        className="block max-w-full"
-                        onLoad={drawOverlay}
-                        />
-                        <canvas
-                        ref={canvasRef}
-                        className="absolute inset-0 pointer-events-none"
-                        />
-                    </div>
-                    </div>
-                ) : null}
+                </pre>
                 </div>
             </div>
-            </>
+        </>
     );
 }

--- a/landing-page/src/components/project/MeiViewerModal.tsx
+++ b/landing-page/src/components/project/MeiViewerModal.tsx
@@ -1,5 +1,6 @@
 import type { MeiFile } from "../../types";
 import { downloadBlob } from "../../utils/download";
+import TruncatedName from "../shared/TruncatedName";
 
 interface Props {
     file: MeiFile;
@@ -20,9 +21,10 @@ export default function MeiViewerModal({ file, onClose }: Props) {
             <div className="fixed z-50 top-[4.5rem] bottom-4 left-1/2 -translate-x-1/2 w-[calc(100vw-2rem)] max-w-5xl bg-[#C8E6E3] rounded-3xl shadow-2xl flex flex-col overflow-hidden animate-fade-in">
                 {/* header */}
                 <div className="flex items-center gap-4 px-6 py-3 border-b border-[#1D3335]/20 shrink-0">
-                <p className="font-mono text-sm text-[#1D3335] font-semibold truncate flex-1">
-                    {file.name}
-                </p>
+                <TruncatedName
+                    name={file.name}
+                    className="font-mono text-sm text-[#1D3335] font-semibold flex-1 min-w-0"
+                />
                 <button
                     onClick={handleExport}
                     className="px-4 py-1.5 bg-white text-[#1D3335] font-semibold rounded-xl hover:opacity-90 cursor-pointer text-sm"

--- a/landing-page/src/components/project/ModelTab.tsx
+++ b/landing-page/src/components/project/ModelTab.tsx
@@ -185,7 +185,9 @@ export default function ModelTab({
     <>
       <div className="mt-6" onClick={() => section.clearSelection()}>
         {project.models.length === 0 ? (
-          <p className="text-white/70 text-sm">no models yet</p>
+          <p className="text-white/70 text-sm">
+            No models yet -- if no model is uploaded, the default model will be used.
+          </p>
         ) : (
           <AssetGrid
             pagedItems={pagedModels}

--- a/landing-page/src/components/project/ProjectDetail.tsx
+++ b/landing-page/src/components/project/ProjectDetail.tsx
@@ -135,6 +135,14 @@ export default function ProjectDetail({
     annSection.setPage(0);
   };
 
+  const TAB_LABELS: Record<string, string> = {
+    images: "Images",
+    models: "Models",
+    annotations: "Detected layers",
+    text: "Detected text",
+    "mei files": "MEI files",
+  }
+
   const tabs = [
      "images",
      "models",
@@ -559,7 +567,7 @@ export default function ProjectDetail({
                     }
                     ${i > 0 ? "-ml-px" : ""}`}
                 >
-                  {tab}
+                  {TAB_LABELS[tab] ?? tab}
                 </button>
               ))}
               <div className="flex-1 border-b border-white/50" />

--- a/landing-page/src/components/project/ProjectDetail.tsx
+++ b/landing-page/src/components/project/ProjectDetail.tsx
@@ -16,6 +16,7 @@ import TextAlignmentsTab from "./TextAlignmentsTab";
 import AnnotationsTab from "./AnnotationsTab";
 import { downloadBlob } from "../../utils/download";
 import CantusSourcePanel from "./CantusSourcePanel";
+import TruncatedName from "../shared/TruncatedName";
 
 const STEPS = [
   "annotate",
@@ -713,7 +714,7 @@ export default function ProjectDetail({
             <span className="text-white/80">selected:</span>
             {usedNames.models.map((name) => (
               <div key={name} className="flex items-center justify-between">
-                <span className="truncate flex-1 mr-2">{name}</span>
+                <TruncatedName name={name} className="flex-1 min-w-0 mr-2" />
                 {stepsUnlocked === 0 && (
                   <button
                     onClick={() =>
@@ -734,7 +735,7 @@ export default function ProjectDetail({
                 <hr className="border-white/40 my-1" />
                 {usedNames.annotations.map((name) => (
                   <div key={name} className="flex items-center justify-between">
-                    <span className="truncate flex-1 mr-2">{name}</span>
+                    <TruncatedName name={name} className="flex-1 min-w-0 mr-2" />
                     {stepsUnlocked < 2 && (
                       <button
                         onClick={() => onUsedNamesChange({ ...usedNames, annotations: usedNames.annotations.filter((n) => n !== name) })}
@@ -750,7 +751,7 @@ export default function ProjectDetail({
               const hasProgress = getImageProgress(name, project.annotations ?? [], project.meiFiles ?? [], stepsUnlocked) !== null;
               return (
                 <div key={name} className="flex items-center justify-between">
-                  <span className="truncate flex-1 mr-2">{name}</span>
+                  <TruncatedName name={name} className="flex-1 min-w-0 mr-2" />
                   {!hasProgress && (
                     <button
                       onClick={() =>

--- a/landing-page/src/components/project/ProjectDetail.tsx
+++ b/landing-page/src/components/project/ProjectDetail.tsx
@@ -115,7 +115,6 @@ export default function ProjectDetail({
     () => minNextStep(usedNames.images, project.annotations ?? [], project.meiFiles ?? [], stepsUnlocked),
     [usedNames.images, project.annotations, project.meiFiles, stepsUnlocked],
   );
-  const sourceLocked = !(usedNames.images.length === 0 || nextStep === 0);
 
   const imgSection = useAssetSection(project.images);
   const mdlSection = useAssetSection(project.models);
@@ -540,7 +539,6 @@ export default function ProjectDetail({
               onBatchStartFolioChange={setBatchStartFolio}
               onBatchEndFolioChange={setBatchEndFolio}
               batchFolioSequence={batchFolioSequence}
-              locked={sourceLocked}
             />
             <div className="flex items-end">
               {tabs.map((tab, i) => (

--- a/landing-page/src/components/project/ProjectDetail.tsx
+++ b/landing-page/src/components/project/ProjectDetail.tsx
@@ -115,6 +115,7 @@ export default function ProjectDetail({
     () => minNextStep(usedNames.images, project.annotations ?? [], project.meiFiles ?? [], stepsUnlocked),
     [usedNames.images, project.annotations, project.meiFiles, stepsUnlocked],
   );
+  const sourceLocked = !(usedNames.images.length === 0 || nextStep === 0);
 
   const imgSection = useAssetSection(project.images);
   const mdlSection = useAssetSection(project.models);
@@ -539,6 +540,7 @@ export default function ProjectDetail({
               onBatchStartFolioChange={setBatchStartFolio}
               onBatchEndFolioChange={setBatchEndFolio}
               batchFolioSequence={batchFolioSequence}
+              locked={sourceLocked}
             />
             <div className="flex items-end">
               {tabs.map((tab, i) => (

--- a/landing-page/src/components/project/ProjectDetail.tsx
+++ b/landing-page/src/components/project/ProjectDetail.tsx
@@ -43,8 +43,7 @@ interface ProjectDetailProps {
     folio?: string,
     sourceId?: string,
     sourceName?: string,
-    originalWidth?: number,
-    originalHeight?: number,
+    originalFile?: File,
   ) => Promise<{ id: string; name: string; folio?: string; sourceId?: string; sourceName?: string }>;
   onUploadModel: (file: File, kind: ModelKind) => Promise<{ id: string; name: string; kind: ModelKind }>;
   onDeleteImage: (imageId: string) => Promise<void>;

--- a/landing-page/src/components/project/ProjectDetail.tsx
+++ b/landing-page/src/components/project/ProjectDetail.tsx
@@ -84,8 +84,11 @@ export default function ProjectDetail({
   textFindingSettings,
 }: ProjectDetailProps) {
   const [activeTab, setActiveTab] = useState<
-    "images" | "models" | "annotations" | "mei files" | "text"
+    "images" | "models" | "generated"
   >("images");
+  const [generatedSubTab, setGeneratedSubTab] = useState<
+    "annotations" | "text" | "mei files"
+  >("annotations");
   const [validationError, setValidationError] = useState<string | null>(null);
   const [projectMenu, setProjectMenu] = useState(false);
   const [projectRenameModal, setProjectRenameModal] = useState(false);
@@ -123,9 +126,7 @@ export default function ProjectDetail({
   const meiSection = useAssetSection(project.meiFiles);
   const annSection = useAssetSection(project.annotations ?? []);
 
-  const switchTab = (
-    tab: "images" | "models" | "annotations" | "mei files",
-  ) => {
+  const switchTab = (tab: "images" | "models" | "generated") => {
     setActiveTab(tab);
     imgSection.clearSelection();
     mdlSection.clearSelection();
@@ -136,9 +137,21 @@ export default function ProjectDetail({
     annSection.setPage(0);
   };
 
+  const switchGeneratedSubTab = (tab: "annotations" | "text" | "mei files") => {
+    setGeneratedSubTab(tab);
+    meiSection.clearSelection();
+    annSection.clearSelection();
+    meiSection.setPage(0);
+    annSection.setPage(0);
+  };
+
   const TAB_LABELS: Record<string, string> = {
     images: "Images",
     models: "Models",
+    generated: "Generated files",
+  }
+
+  const GENERATED_SUBTAB_LABELS: Record<string, string> = {
     annotations: "Detected layers",
     text: "Detected text",
     "mei files": "MEI files",
@@ -147,9 +160,12 @@ export default function ProjectDetail({
   const tabs = [
      "images",
      "models",
-     ...(stepsUnlocked >= 1 ? ["annotations", "text"] : []),
-     ...(stepsUnlocked >= 3 ? ["mei files"] : []),
+     ...(stepsUnlocked >= 1 ? ["generated"] : []),
    ] as const;
+
+  const generatedSubTabs = (
+    ["annotations", "text", ...(stepsUnlocked >= 3 ? ["mei files" as const] : [])] as const
+  );
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -194,7 +210,7 @@ export default function ProjectDetail({
             });
           });
         }
-        if (activeTab === "annotations" && annSection.selectedIds.size > 0) {
+        if (activeTab === "generated" && generatedSubTab === "annotations" && annSection.selectedIds.size > 0) {
           const ids = [...annSection.selectedIds];
           const deleted = new Set(ids);
           annSection.clearSelection();
@@ -205,7 +221,7 @@ export default function ProjectDetail({
             });
           });
         }
-        if (activeTab === "mei files" && meiSection.selectedIds.size > 0) {
+        if (activeTab === "generated" && generatedSubTab === "mei files" && meiSection.selectedIds.size > 0) {
           const ids = [...meiSection.selectedIds];
           const deleted = new Set(ids);
           meiSection.clearSelection();
@@ -222,6 +238,7 @@ export default function ProjectDetail({
     return () => window.removeEventListener("keydown", handler);
   }, [
     activeTab,
+    generatedSubTab,
     imgSection,
     mdlSection,
     meiSection,
@@ -448,7 +465,7 @@ export default function ProjectDetail({
                   mdlSection.clearSelection();
                 },
               )}
-              {activeTab === "annotations" && annSection.selectedIds.size > 0 && (
+              {activeTab === "generated" && generatedSubTab === "annotations" && annSection.selectedIds.size > 0 && (
                 <>
                   {selectionButtons(
                     "annotation",
@@ -500,7 +517,7 @@ export default function ProjectDetail({
                   </button>
                 </>
               )}
-              {activeTab === "mei files" && meiSection.selectedIds.size > 0 && (
+              {activeTab === "generated" && generatedSubTab === "mei files" && meiSection.selectedIds.size > 0 && (
                 <>
                   <button
                     onClick={() =>
@@ -555,11 +572,7 @@ export default function ProjectDetail({
               {tabs.map((tab, i) => (
                 <button
                   key={tab}
-                  onClick={() =>
-                    switchTab(
-                      tab as "images" | "models" | "annotations" | "mei files",
-                    )
-                  }
+                  onClick={() => switchTab(tab as "images" | "models" | "generated")}
                   className={`relative px-8 pt-3 pb-2 text-2xl font-bold italic rounded-t-xl cursor-pointer transition-colors
                     ${
                       activeTab === tab
@@ -616,30 +629,46 @@ export default function ProjectDetail({
                 textFindingSettings={textFindingSettings}
               />
             )}
-            {activeTab === "annotations" && (
-              <AnnotationsTab
-                annotations={project.annotations}
-                images={project.images}
-                projectId={project.id}
-                section={annSection}
-                usedNames={usedNames}
-                onUsedNamesChange={onUsedNamesChange}
-              />
-            )}
-            {activeTab === "text" && (
-              <TextAlignmentsTab
-                textAlignments={project.textAlignments}
-                images={project.images}
-                projectId={project.id}
-              />
-            )}
-            {activeTab === "mei files" && (
-              <MeiTab
-                project={project}
-                section={meiSection}
-                onUpdateProject={onUpdateProject}
-                onDeleteMei={onDeleteMei}
-              />
+            {activeTab === "generated" && (
+              <>
+                <div className="flex gap-2 mt-6 mb-4">
+                  {generatedSubTabs.map((sub) => (
+                    <button
+                      key={sub}
+                      onClick={() => switchGeneratedSubTab(sub)}
+                      className={`px-4 py-1.5 rounded-lg text-sm font-semibold transition-colors cursor-pointer
+                        ${generatedSubTab === sub ? "bg-white text-[#4AADAA]" : "text-white/60 hover:text-white/90"}`}
+                    >
+                      {GENERATED_SUBTAB_LABELS[sub]}
+                    </button>
+                  ))}
+                </div>
+                {generatedSubTab === "annotations" && (
+                  <AnnotationsTab
+                    annotations={project.annotations}
+                    images={project.images}
+                    projectId={project.id}
+                    section={annSection}
+                    usedNames={usedNames}
+                    onUsedNamesChange={onUsedNamesChange}
+                  />
+                )}
+                {generatedSubTab === "text" && (
+                  <TextAlignmentsTab
+                    textAlignments={project.textAlignments}
+                    images={project.images}
+                    projectId={project.id}
+                  />
+                )}
+                {generatedSubTab === "mei files" && stepsUnlocked >= 3 && (
+                  <MeiTab
+                    project={project}
+                    section={meiSection}
+                    onUpdateProject={onUpdateProject}
+                    onDeleteMei={onDeleteMei}
+                  />
+                )}
+              </>
             )}
           </div>
         </div>

--- a/landing-page/src/components/project/TextAlignmentViewerModal.tsx
+++ b/landing-page/src/components/project/TextAlignmentViewerModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useCallback, useEffect } from "react";
 import { type TextAlignment } from "../../types";
 import { apiFetch } from "../../lib/apiFetch";
+import TruncatedName from "../shared/TruncatedName";
 
 interface SylBox {
     syl: string;
@@ -88,9 +89,10 @@ export default function TextAlignmentViewerModal({ alignment, projectId, onClose
             <div className="fixed top-14 inset-x-0 bottom-0 z-40 bg-black/60" onClick={onClose} />
             <div className="fixed z-50 top-[4.5rem] bottom-4 left-1/2 -translate-x-1/2 w-[calc(100vw-2rem)] max-w-5xl bg-[#C8E6E3] rounded-3xl shadow-2xl flex flex-col overflow-hidden animate-fade-in">
                 <div className="flex items-center gap-4 px-6 py-3 border-b border-[#1D3335]/20 shrink-0">
-                    <p className="font-mono text-sm text-[#1D3335] font-semibold truncate flex-1">
-                        {label ?? alignment.imageName}
-                    </p>
+                    <TruncatedName
+                        name={label ?? alignment.imageName}
+                        className="font-mono text-sm text-[#1D3335] font-semibold flex-1 min-w-0"
+                    />
                     <span className="text-xs text-[#1D3335]/60">
                         {alignment.syllableCount} syllable{alignment.syllableCount !== 1 ? "s" : ""}
                     </span>

--- a/landing-page/src/components/project/TextAlignmentsTab.tsx
+++ b/landing-page/src/components/project/TextAlignmentsTab.tsx
@@ -2,6 +2,7 @@ import { Fragment, useState } from "react";
 import type { ProjectImage, TextAlignment } from "../../types";
 import { AuthImage } from "../shared/AuthImage";
 import TextAlignmentViewerModal from "./TextAlignmentViewerModal";
+import TruncatedName from "../shared/TruncatedName";
 import { sortBySourceThenFolio, sourceGroupLabel } from "../../utils/folio";
 
 interface TextAlignmentsTabProps {
@@ -92,9 +93,10 @@ export default function TextAlignmentsTab({
                     </button>
                   </div>
                 </div>
-                <span className="text-sm text-white truncate">
-                  {labelById.get(set.id)}
-                </span>
+                <TruncatedName
+                  name={labelById.get(set.id) ?? ""}
+                  className="text-sm text-white"
+                />
                 <span className="text-xs text-white/50">
                   {set.syllableCount} syllable
                   {set.syllableCount !== 1 ? "s" : ""}

--- a/landing-page/src/components/shared/AssetGrid.tsx
+++ b/landing-page/src/components/shared/AssetGrid.tsx
@@ -25,6 +25,7 @@ interface AssetGridProps<T extends AssetItem> {
   renderThumbnail: (item: T) => ReactNode;
   getItemBadge?: (name: string) => string | null;
   groupBy?: (item: T) => string;
+  onUse?: (item: T) => void;
 }
 
 export default function AssetGrid<T extends AssetItem>({
@@ -36,6 +37,7 @@ export default function AssetGrid<T extends AssetItem>({
   renderThumbnail,
   getItemBadge,
   groupBy,
+  onUse,
 }: AssetGridProps<T>) {
   return (
     <>
@@ -69,6 +71,17 @@ export default function AssetGrid<T extends AssetItem>({
                   }}
                 >
                   {renderThumbnail(item)}
+                  {onUse && !used && (
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onUse(item);
+                      }}
+                      className="absolute top-1.5 left-1.5 z-20 px-1.5 py-0.5 bg-black/40 text-white text-[9px] font-mono rounded hover:bg-black/70 cursor-pointer"
+                    >
+                      use
+                    </button>
+                  )}
                   {badge && (
                     <div className="absolute bottom-0 inset-x-0 flex justify-center pb-1.5 pointer-events-none">
                       <span className="bg-[#1D3335]/80 text-white text-xs px-2 py-0.5 rounded-full">

--- a/landing-page/src/components/shared/AssetGrid.tsx
+++ b/landing-page/src/components/shared/AssetGrid.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { Fragment } from "react";
 import type React from "react";
 import Paginator from "./Paginator";
+import TruncatedName from "./TruncatedName";
 
 interface AssetItem {
   id: string;
@@ -91,9 +92,10 @@ export default function AssetGrid<T extends AssetItem>({
                   )}
                 </div>
                 <div className="flex items-center justify-between gap-1">
-                  <span className={`text-sm text-white truncate ${used ? "opacity-40" : ""}`}>
-                    {item.name}
-                  </span>
+                  <TruncatedName
+                    name={item.name}
+                    className={`text-sm text-white ${used ? "opacity-40" : ""}`}
+                  />
                   {!used && (
                     <button
                       onClick={(e) => {

--- a/landing-page/src/components/shared/TruncatedName.tsx
+++ b/landing-page/src/components/shared/TruncatedName.tsx
@@ -26,13 +26,16 @@ export default function TruncatedName({
   const tail = hasHead ? name.slice(name.length - tailLength) : name;
 
   return (
-    <span className={`inline-flex min-w-0 max-w-full ${className}`} title={name + suffix}>
+    <span
+      className={`inline-flex min-w-0 max-w-full overflow-hidden ${className}`}
+      title={name + suffix}
+    >
       {head && (
         <span className="overflow-hidden text-ellipsis whitespace-nowrap min-w-0">
           {head}
         </span>
       )}
-      <span className="overflow-hidden text-ellipsis whitespace-nowrap shrink-0">
+      <span className="min-w-0 max-w-full overflow-hidden text-ellipsis whitespace-nowrap shrink-0">
         {tail}
         {suffix}
       </span>

--- a/landing-page/src/components/shared/TruncatedName.tsx
+++ b/landing-page/src/components/shared/TruncatedName.tsx
@@ -1,0 +1,41 @@
+interface TruncatedNameProps {
+  /** The (possibly long) distinguishing part of the name, e.g. a filename or folio label. */
+  name: string;
+  /** Always-visible text appended after `name`, not counted toward truncation (e.g. "_annotations"). */
+  suffix?: string;
+  /** How many trailing characters of `name` to always keep visible (default 14) — this is
+   * usually where the distinguishing part (a folio number, an extension) lives, so the
+   * ellipsis eats into the shared prefix instead of hiding the useful part. */
+  tailLength?: number;
+  className?: string;
+}
+
+// Tailwind's `truncate` ellipsizes from the end, which hides exactly the part
+// (a folio number like "_010r") that distinguishes otherwise-identical, long
+// manuscript filenames from each other. This instead always keeps the last
+// `tailLength` characters of `name` (plus `suffix`, if any) visible, and lets
+// only the shared prefix ellipsize when space runs out.
+export default function TruncatedName({
+  name,
+  suffix = "",
+  tailLength = 14,
+  className = "",
+}: TruncatedNameProps) {
+  const hasHead = name.length > tailLength;
+  const head = hasHead ? name.slice(0, name.length - tailLength) : "";
+  const tail = hasHead ? name.slice(name.length - tailLength) : name;
+
+  return (
+    <span className={`inline-flex min-w-0 max-w-full ${className}`} title={name + suffix}>
+      {head && (
+        <span className="overflow-hidden text-ellipsis whitespace-nowrap min-w-0">
+          {head}
+        </span>
+      )}
+      <span className="overflow-hidden text-ellipsis whitespace-nowrap shrink-0">
+        {tail}
+        {suffix}
+      </span>
+    </span>
+  );
+}

--- a/landing-page/src/components/workflow/MeiCompareModal.tsx
+++ b/landing-page/src/components/workflow/MeiCompareModal.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from "react";
 import type { MeiFile, ProjectImage } from "../../types";
 import { diffZones } from "../../utils/meiZoneDiff";
 import MeiImageDiffView from "./MeiImageDiffView";
+import TruncatedName from "../shared/TruncatedName";
 
 interface Props {
     originalFiles: MeiFile[];
@@ -57,13 +58,13 @@ export default function MeiCompareModal({ originalFiles, correctedFiles, onClose
                     <button
                     key={p.corrected.id}
                     onClick={() => { setSelectedIndex(i); setViewMode("xml"); }}
-                    className={`px-3 py-1 rounded-lg text-xs font-semibold transition-colors cursor-pointer truncate max-w-[140px] ${
+                    className={`px-3 py-1 rounded-lg text-xs font-semibold transition-colors cursor-pointer max-w-[140px] ${
                         i === selectedIndex
                         ? "bg-white text-[#4AADAA]"
                         : "text-[#1D3335]/60 hover:text-[#1D3335]"
                     }`}
                     >
-                    {p.name}
+                    <TruncatedName name={p.name} tailLength={10} className="min-w-0" />
                     </button>
                 ))}
                 </div>

--- a/landing-page/src/components/workflow/MeiImageDiffView.tsx
+++ b/landing-page/src/components/workflow/MeiImageDiffView.tsx
@@ -18,7 +18,7 @@ export default function MeiImageDiffView({ imageId, diff, imageName }: MeiImageD
   useEffect(() => {
     if (!imageId) return;
     let url: string | null = null;
-    apiFetch(`/api/images/${imageId}`)
+    apiFetch(`/api/images/${imageId}/original`)
       .then((r) => (r.ok ? r.blob() : Promise.reject("fetch failed")))
       .then((blob) => {
         url = URL.createObjectURL(blob);

--- a/landing-page/src/hooks/useEncodingFlow.ts
+++ b/landing-page/src/hooks/useEncodingFlow.ts
@@ -33,7 +33,11 @@ export function useEncodingFlow(
     stem?: string;
   }) => {
     const pair = pendingBatchPairs[ev.item];
-    const stem = ev.stem ?? pair?.xmlFile.name.replace(/\.xml$/i, "") ?? `item-${ev.item}`;
+    const stem =
+      ev.stem ??
+      pair?.imageFile.name.replace(/\.[^.]+$/, "") ??
+      pair?.xmlFile.name.replace(/\.xml$/i, "") ??
+      `item-${ev.item}`;
     const imageName = pair?.imageFile.name ?? ev.image_name;
     const xmlBytes = Uint8Array.from(atob(ev.mei_base64), (c) => c.charCodeAt(0));
     const xmlText = new TextDecoder().decode(xmlBytes);
@@ -66,7 +70,10 @@ export function useEncodingFlow(
     manifest: Record<string, unknown> | null;
   }) => {
     setNeonManifest(ev.manifest ?? null);
-    const stem = pendingXmlFile?.name.replace(".xml", "") ?? "output";
+    const stem =
+      pendingImageFile?.name.replace(/\.[^.]+$/, "") ??
+      pendingXmlFile?.name.replace(/\.xml$/i, "") ??
+      "output";
     settleMeiContent({ bytes: ev.mei_base64, stem });
     const xmlBytes = Uint8Array.from(atob(ev.mei_base64), (c) => c.charCodeAt(0));
     const xmlText = new TextDecoder().decode(xmlBytes);

--- a/landing-page/src/utils/imageResize.ts
+++ b/landing-page/src/utils/imageResize.ts
@@ -1,60 +1,46 @@
-export const MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024;
-export const TARGET_RESIZE_BYTES = 2 * 1024 * 1024;
+export const MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024; // warn above this
+export const TARGET_RESIZE_BYTES = 2 * 1024 * 1024; // resize aims for this
 
 export function getOversizedFiles(
-    files: File[],
-    thresholdBytes: number = MAX_IMAGE_SIZE_BYTES,
-) : File[] {
-    return files.filter((f) => f.size > thresholdBytes);
-}
-
-export interface ResizedImage {
-    file: File;
-    originalWidth: number;
-    originalHeight: number;
+  files: File[],
+  thresholdBytes: number = MAX_IMAGE_SIZE_BYTES,
+): File[] {
+  return files.filter((f) => f.size > thresholdBytes);
 }
 
 // Downscales/re-encodes an image file as JPEG until it's under targetBytes
 // (or a bounded number of attempts is exhausted - some pathological images
 // may not compress below the target, so this is best-effort, not guaranteed).
-// Also reports the pre-resize pixel dimensions, needed so the backend can
-// later rescale this image's MEI zone coordinates back to this original size.
 export async function resizeImageFile(
-    file: File,
-    targetBytes: number = TARGET_RESIZE_BYTES,
-): Promise<ResizedImage> {
-    const bitmap = await createImageBitmap(file);
-    const originalWidth = bitmap.width;
-    const originalHeight = bitmap.height;
-    // area scales roughly with byte size for a given quality, so this gives a
-    // reasonable starting point; the loop below corrects if it's still too big
-    let scale = Math.min(1, Math.sqrt(targetBytes / file.size));
-    let quality = 0.9;
-    let blob: Blob | null = null;
+  file: File,
+  targetBytes: number = TARGET_RESIZE_BYTES,
+): Promise<File> {
+  const bitmap = await createImageBitmap(file);
+  // area scales roughly with byte size for a given quality, so this gives a
+  // reasonable starting point; the loop below corrects if it's still too big
+  let scale = Math.min(1, Math.sqrt(targetBytes / file.size));
+  let quality = 0.9;
+  let blob: Blob | null = null;
 
-    for (let attempt = 0; attempt < 6; attempt++) {
-        const width = Math.max(1, Math.round(bitmap.width * scale));
-        const height = Math.max(1, Math.round(bitmap.height * scale));
-        const canvas = document.createElement("canvas");
-        canvas.width = width;
-        canvas.height = height;
-        canvas.getContext("2d")!.drawImage(bitmap, 0, 0, width, height);
-        blob = await new Promise<Blob>((resolve) =>
-            canvas.toBlob((b) => resolve(b!), "image/jpeg", quality),
-        );
-        if (blob.size <= targetBytes) break;
-        if (quality > 0.5) {
-            quality -= 0.15;
-        } else {
-            scale *=0.8;
-        }
+  for (let attempt = 0; attempt < 6; attempt++) {
+    const width = Math.max(1, Math.round(bitmap.width * scale));
+    const height = Math.max(1, Math.round(bitmap.height * scale));
+    const canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    canvas.getContext("2d")!.drawImage(bitmap, 0, 0, width, height);
+    blob = await new Promise<Blob>((resolve) =>
+      canvas.toBlob((b) => resolve(b!), "image/jpeg", quality),
+    );
+    if (blob.size <= targetBytes) break;
+    if (quality > 0.5) {
+      quality -= 0.15;
+    } else {
+      scale *= 0.8;
     }
-    bitmap.close();
+  }
+  bitmap.close();
 
-    const newName = file.name.replace(/\.[^./\\]+$/, "") + ".jpg";
-    return {
-        file: new File([blob!], newName, { type: "image/jpeg" }),
-        originalWidth,
-        originalHeight,
-    };
+  const newName = file.name.replace(/\.[^./\\]+$/, "") + ".jpg";
+  return new File([blob!], newName, { type: "image/jpeg" });
 }


### PR DESCRIPTION
ref: #123, #127, #129, #130

- folio select persists
- removed score view from mei modal
- tab modifications
- truncated file names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Original image files can now be retained, retrieved, and used for viewing and comparison.
  - Added an option to use previously unused assets directly from asset grids.
  - Grouped annotations, text alignments, and MEI files under a new Generated files tab.

- **Improvements**
  - MEI generation better preserves original image dimensions and filenames.
  - Long filenames now display consistently with clearer truncation and visible suffixes.
  - Source navigation now preserves selected folios when revisiting cached sources.
  - Updated MEI viewing and model messaging for greater clarity.

- **Bug Fixes**
  - Improved cleanup when files are removed concurrently.
  - Storage calculations now include original image files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->