### PR TITLE
fix: wire StafflinesTab into the generated-files subtab switcher

### DIFF
--- a/landing-page/src/components/project/ProjectDetail.tsx
+++ b/landing-page/src/components/project/ProjectDetail.tsx
@@ -88,7 +88,7 @@ export default function ProjectDetail({
     "images" | "models" | "generated"
   >("images");
   const [generatedSubTab, setGeneratedSubTab] = useState<
-    "annotations" | "text" | "mei files"
+    "annotations" | "text" | "stafflines" | "mei files"
   >("annotations");
   const [validationError, setValidationError] = useState<string | null>(null);
   const [projectMenu, setProjectMenu] = useState(false);
@@ -138,7 +138,7 @@ export default function ProjectDetail({
     annSection.setPage(0);
   };
 
-  const switchGeneratedSubTab = (tab: "annotations" | "text" | "mei files") => {
+  const switchGeneratedSubTab = (tab: "annotations" | "text" | "stafflines" | "mei files") => {
     setGeneratedSubTab(tab);
     meiSection.clearSelection();
     annSection.clearSelection();
@@ -155,12 +155,13 @@ export default function ProjectDetail({
   const GENERATED_SUBTAB_LABELS: Record<string, string> = {
     annotations: "Detected layers",
     text: "Detected text",
+    stafflines: "Stafflines",
     "mei files": "MEI files",
   }
 
   const tabs = ["images", "models", "generated"] as const;
 
-  const generatedSubTabs = ["annotations", "text", "mei files"] as const;
+  const generatedSubTabs = ["annotations", "text", "stafflines", "mei files"] as const;
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -651,6 +652,13 @@ export default function ProjectDetail({
                 {generatedSubTab === "text" && (
                   <TextAlignmentsTab
                     textAlignments={project.textAlignments}
+                    images={project.images}
+                    projectId={project.id}
+                  />
+                )}
+                {generatedSubTab === "stafflines" && (
+                  <StafflinesTab
+                    stafflines={project.stafflines}
                     images={project.images}
                     projectId={project.id}
                   />


### PR DESCRIPTION
## Problem

CI failed on `main` after PR #53 merged ([run 30931964838](https://github.com/DDMAL/mothra/actions/runs/30931964838)):

```
src/components/project/ProjectDetail.tsx(17,1): error TS6133: 'StafflinesTab' is declared but its value is never read.
```

`tsc -b` is a blocking step in the frontend Docker build, so this failed the whole `backend` image build.

## Root cause

Not a fresh bug -- a lost-wiring merge casualty. My `e403c13` commit (on `kyrie/staff-finding`) wired `StafflinesTab` into `ProjectDetail.tsx`'s tab switcher, but against the old flat `activeTab` union. Concurrently on `main`, that whole structure was refactored into the current "generated" tab + `generatedSubTab` sub-switcher (`b959dce`, `d1d0be3`). When PR #53 merged into `main`, the merge kept the `import StafflinesTab` line but silently dropped the actual wiring, since it targeted an architecture that no longer existed -- leaving the Stafflines feature (fully built end-to-end: detection, `Project.stafflines` data plumbing, `StafflinesTab`/`StafflineViewerModal`) unreachable in the UI.

## Fix

Adds `stafflines` as a fourth `generatedSubTab` option alongside `annotations`/`text`/`mei files`, following the exact existing pattern in `ProjectDetail.tsx`: extends the `generatedSubTab`/`switchGeneratedSubTab` union types, adds a `GENERATED_SUBTAB_LABELS` entry and a `generatedSubTabs` array entry, and renders `StafflinesTab` with the props it already expects (`stafflines`, `images`, `projectId`). No other files needed changes -- `Project.stafflines` is already populated end-to-end via `AppRouter.tsx`.

## Verification

- `npx tsc -b` -- clean, no errors
- `npx vite build` -- succeeds, reproducing the failing CI step
- Manually confirmed the "Stafflines" sub-tab appears in "Generated files" alongside the other three

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Stafflines subtab to project details.
  * Staffline data and related images are now available within the generated files section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->