### PR TITLE
Surface staffline rhythm diagnostics + close text-batch staffline gap

### DIFF
--- a/landing-page/scripts/tasks_text_batch.py
+++ b/landing-page/scripts/tasks_text_batch.py
@@ -16,6 +16,7 @@ from job_store import publish_event, check_cancelled, JobCancelled
 from auth_api import get_db_conn, release_db_conn
 from text_api import TEXT_API_URL, _stream_multipart, _music_boxes_for_image, _mask_json_for_image
 from yolo_inference import resolve_yolo_models, write_annotation
+from staffline_stage import run_staffline_detection, has_class, STAFFLINE_CLASS_ID
 
 @celery_app.task(name="text_batch.run")
 def run_text_batch_task(job_id, project_id, body):
@@ -67,13 +68,29 @@ def run_text_batch_task(job_id, project_id, body):
         for image_id, (name, data, mime) in zip(image_ids, images):
             check_cancelled(job_id)
             pil_img = Image.open(io.BytesIO(data)).convert("RGB")
-            yolo_txt = yolo_models.infer(np.array(pil_img))
-            write_annotation(cur, con, project_id, image_id, name, yolo_txt,
+            img_arr = np.array(pil_img)
+            yolo_txt = yolo_models.infer(img_arr)
+            ann_id = write_annotation(cur, con, project_id, image_id, name, yolo_txt,
                              yolo_models.stored_model_id, yolo_models.model_label, yolo_models.model_hash)
             music_boxes_by_index.append(_music_boxes_for_image(project_id, name, data))
             mask_json_by_index.append(_mask_json_for_image(project_id, name, data) if body["masking_enabled"] else None)
             n = len(yolo_txt.splitlines()) if yolo_txt else 0
             publish({"type": "log", "message": f"{name}: layer separation done ({n} detection(s))"})
+
+            # Mirrors tasks_predict.py's own predict-job pipeline: this path
+            # also runs fresh YOLO layer-separation per image and previously
+            # never called staffline_stage.py, so batch-run images got no
+            # staffline_detections row at all (see
+            # documentation_allons-y/STAFFLINE_INTEGRATION_FOLLOWUPS.md's
+            # "batch_api.py's text-batch-run path" bullet).
+            if has_class(yolo_txt, STAFFLINE_CLASS_ID):
+                for sf_ev in run_staffline_detection(
+                    job_id, cur, con, project_id, image_id, name, ann_id, img_arr, yolo_txt,
+                ):
+                    if sf_ev.get("type") == "error":
+                        publish({"type": "log", "message": f"staffline-detection: {sf_ev.get('message', 'failed')}"})
+                    else:
+                        publish(sf_ev)
         publish({"type": "stage_done", "name": "checking"})
 
         publish({"type": "stage", "name": "validating"})

--- a/landing-page/src/components/project/RhythmChart.tsx
+++ b/landing-page/src/components/project/RhythmChart.tsx
@@ -1,0 +1,126 @@
+import { type RhythmGapSummary } from "../../lib/rhythmGaps";
+
+// Inline-SVG re-creation of staff-finding/scripts/group_staves.py's
+// "Gap Distribution (Consecutive Fits)" diagnostic plot (normally only
+// produced by run_page.py, off the landing-page request path -- see
+// rhythmGaps.ts's module comment). No charting library: this is one bar
+// chart, consistent with the rest of the codebase avoiding new heavy deps
+// for a single visual.
+
+const PALETTE = ["#4AADAA", "#FFA500", "#E87BF7", "#F76B6B", "#6BF7A5", "#F7E16B"];
+const ANOMALY_COLOR = "#FF3B30";
+const NOISE_FLOOR_COLOR = "#1D3335";
+const CUT_THRESHOLD_COLOR = "#FF3B30";
+const MAX_INTERP_COLOR = "#FFA500";
+
+const CHART_H = 260;
+const PAD_L = 44;
+const PAD_R = 16;
+const PAD_T = 16;
+const PAD_B = 28;
+const BAR_GAP = 3;
+const MIN_BAR_W = 4;
+
+interface Props {
+  summary: RhythmGapSummary;
+}
+
+export default function RhythmChart({ summary }: Props) {
+  const { bars, noiseFloorPx, cutThresholdPx, maxInterpGapPx } = summary;
+  const yMax = Math.max(maxInterpGapPx, ...bars.map((b) => b.gapPx)) * 1.08 || 1;
+  const barW = Math.max(MIN_BAR_W, 12);
+  const chartW = PAD_L + PAD_R + bars.length * (barW + BAR_GAP);
+  const plotH = CHART_H - PAD_T - PAD_B;
+
+  const yToPx = (v: number) => PAD_T + plotH - (v / yMax) * plotH;
+
+  return (
+    <div className="w-full overflow-x-auto">
+      <svg
+        viewBox={`0 0 ${chartW} ${CHART_H}`}
+        width={chartW}
+        height={CHART_H}
+        className="min-w-full"
+      >
+        {/* axes */}
+        <line x1={PAD_L} y1={PAD_T} x2={PAD_L} y2={PAD_T + plotH} stroke="#1D3335" strokeWidth={1} />
+        <line
+          x1={PAD_L}
+          y1={PAD_T + plotH}
+          x2={chartW - PAD_R}
+          y2={PAD_T + plotH}
+          stroke="#1D3335"
+          strokeWidth={1}
+        />
+        {[0, 0.25, 0.5, 0.75, 1].map((f) => (
+          <text
+            key={f}
+            x={PAD_L - 6}
+            y={yToPx(yMax * f) + 3}
+            textAnchor="end"
+            fontSize={9}
+            fontFamily="monospace"
+            fill="#1D3335"
+            opacity={0.6}
+          >
+            {Math.round(yMax * f)}
+          </text>
+        ))}
+
+        {/* reference lines */}
+        <line
+          x1={PAD_L}
+          y1={yToPx(noiseFloorPx)}
+          x2={chartW - PAD_R}
+          y2={yToPx(noiseFloorPx)}
+          stroke={NOISE_FLOOR_COLOR}
+          strokeOpacity={0.35}
+          strokeDasharray="2,2"
+        />
+        <line
+          x1={PAD_L}
+          y1={yToPx(cutThresholdPx)}
+          x2={chartW - PAD_R}
+          y2={yToPx(cutThresholdPx)}
+          stroke={CUT_THRESHOLD_COLOR}
+          strokeDasharray="5,3"
+        />
+        <line
+          x1={PAD_L}
+          y1={yToPx(maxInterpGapPx)}
+          x2={chartW - PAD_R}
+          y2={yToPx(maxInterpGapPx)}
+          stroke={MAX_INTERP_COLOR}
+          strokeDasharray="5,3"
+        />
+
+        {/* bars */}
+        {bars.map((b, i) => {
+          const x = PAD_L + i * (barW + BAR_GAP);
+          const y = yToPx(b.gapPx);
+          const h = PAD_T + plotH - y;
+          const color = b.isAnomalous ? ANOMALY_COLOR : PALETTE[b.staveId % PALETTE.length];
+          return <rect key={i} x={x} y={y} width={barW} height={Math.max(h, 0.5)} fill={color} />;
+        })}
+      </svg>
+      <div className="flex flex-wrap gap-x-4 gap-y-1 mt-2 text-[10px] font-mono text-[#1D3335]/70">
+        <span>
+          <span style={{ color: NOISE_FLOOR_COLOR }}>┅</span> noise floor ({noiseFloorPx.toFixed(1)}px)
+        </span>
+        <span>
+          <span style={{ color: CUT_THRESHOLD_COLOR }}>┅</span> cut threshold ({cutThresholdPx.toFixed(1)}px)
+        </span>
+        <span>
+          <span style={{ color: MAX_INTERP_COLOR }}>┅</span> max interp. gap ({maxInterpGapPx.toFixed(1)}px)
+        </span>
+        <span>
+          <span style={{ color: ANOMALY_COLOR }}>■</span> flagged stave
+        </span>
+      </div>
+      <p className="mt-2 text-[#1D3335]/50 text-[11px] font-mono">
+        approximated client-side from stored per-line fit data — thresholds mirror
+        group_staves.py's own multipliers, not its exact valley-detection pass
+      </p>
+    </div>
+  );
+}

--- a/landing-page/src/components/project/RhythmChart.tsx
+++ b/landing-page/src/components/project/RhythmChart.tsx
@@ -34,14 +34,26 @@ export default function RhythmChart({ summary }: Props) {
 
   const yToPx = (v: number) => PAD_T + plotH - (v / yMax) * plotH;
 
+  const description = bars
+    .map(
+      (b) =>
+        `stave ${b.staveId} gap ${b.gapIndex}: ${b.gapPx.toFixed(1)}px${b.isAnomalous ? " (flagged)" : ""}`,
+    )
+    .join("; ");
+
   return (
     <div className="w-full overflow-x-auto">
       <svg
+        role="img"
+        aria-labelledby="rhythm-chart-title"
+        aria-describedby="rhythm-chart-desc"
         viewBox={`0 0 ${chartW} ${CHART_H}`}
         width={chartW}
         height={CHART_H}
         className="min-w-full"
       >
+        <title id="rhythm-chart-title">Staffline rhythm gap distribution</title>
+        <desc id="rhythm-chart-desc">{description}</desc>
         {/* axes */}
         <line x1={PAD_L} y1={PAD_T} x2={PAD_L} y2={PAD_T + plotH} stroke="#1D3335" strokeWidth={1} />
         <line
@@ -94,27 +106,44 @@ export default function RhythmChart({ summary }: Props) {
           strokeDasharray="5,3"
         />
 
-        {/* bars */}
+        {/* bars -- anomalous ones get a dark outline too, not just the red
+            fill, so they're distinguishable without relying on color alone */}
         {bars.map((b, i) => {
           const x = PAD_L + i * (barW + BAR_GAP);
           const y = yToPx(b.gapPx);
           const h = PAD_T + plotH - y;
           const color = b.isAnomalous ? ANOMALY_COLOR : PALETTE[b.staveId % PALETTE.length];
-          return <rect key={i} x={x} y={y} width={barW} height={Math.max(h, 0.5)} fill={color} />;
+          return (
+            <rect
+              key={i}
+              x={x}
+              y={y}
+              width={barW}
+              height={Math.max(h, 0.5)}
+              fill={color}
+              stroke={b.isAnomalous ? "#1D3335" : "none"}
+              strokeWidth={b.isAnomalous ? 1.5 : 0}
+            >
+              <title>
+                stave {b.staveId} gap {b.gapIndex}: {b.gapPx.toFixed(1)}px
+                {b.isAnomalous ? " (flagged)" : ""}
+              </title>
+            </rect>
+          );
         })}
       </svg>
       <div className="flex flex-wrap gap-x-4 gap-y-1 mt-2 text-[10px] font-mono text-[#1D3335]/70">
         <span>
-          <span style={{ color: NOISE_FLOOR_COLOR }}>┅</span> noise floor ({noiseFloorPx.toFixed(1)}px)
+          <span className="text-[#1D3335]">┅</span> noise floor ({noiseFloorPx.toFixed(1)}px)
         </span>
         <span>
-          <span style={{ color: CUT_THRESHOLD_COLOR }}>┅</span> cut threshold ({cutThresholdPx.toFixed(1)}px)
+          <span className="text-[#FF3B30]">┅</span> cut threshold ({cutThresholdPx.toFixed(1)}px)
         </span>
         <span>
-          <span style={{ color: MAX_INTERP_COLOR }}>┅</span> max interp. gap ({maxInterpGapPx.toFixed(1)}px)
+          <span className="text-[#FFA500]">┅</span> max interp. gap ({maxInterpGapPx.toFixed(1)}px)
         </span>
         <span>
-          <span style={{ color: ANOMALY_COLOR }}>■</span> flagged stave
+          <span className="text-[#FF3B30]">■</span> flagged stave
         </span>
       </div>
       <p className="mt-2 text-[#1D3335]/50 text-[11px] font-mono">

--- a/landing-page/src/components/project/StafflineViewerModal.tsx
+++ b/landing-page/src/components/project/StafflineViewerModal.tsx
@@ -1,6 +1,8 @@
-import { useState, useRef, useCallback, useEffect } from "react";
+import { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import { type StafflineSet, type JsomrLineRecord } from "../../types";
 import { apiFetch } from "../../lib/apiFetch";
+import { computeRhythmGaps } from "../../lib/rhythmGaps";
+import RhythmChart from "./RhythmChart";
 
 type ViewState =
     | { status: "loading" }
@@ -24,8 +26,14 @@ interface Props {
 export default function StafflineViewerModal({ detection, projectId, onClose, label }: Props) {
     const [viewState, setViewState] = useState<ViewState>({ status: "loading" });
     const [notesOpen, setNotesOpen] = useState(false);
+    const [tab, setTab] = useState<"overlay" | "rhythm">("overlay");
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const imgRef = useRef<HTMLImageElement>(null);
+
+    const rhythmSummary = useMemo(
+        () => (viewState.status === "ready" ? computeRhythmGaps(viewState.records) : null),
+        [viewState],
+    );
 
     const anomalousStaveIds =
         viewState.status === "ready"
@@ -159,6 +167,23 @@ export default function StafflineViewerModal({ detection, projectId, onClose, la
                             {anomalousStaveIds.size} flagged for review
                         </span>
                     )}
+                    {viewState.status === "ready" && rhythmSummary && (
+                        <div className="flex bg-[#1D3335]/10 rounded-full p-0.5 text-xs font-mono">
+                            {(["overlay", "rhythm"] as const).map((t) => (
+                                <button
+                                    key={t}
+                                    onClick={() => setTab(t)}
+                                    className={`px-3 py-1 rounded-full cursor-pointer transition-colors ${
+                                        tab === t
+                                            ? "bg-[#1D3335] text-white"
+                                            : "text-[#1D3335]/60 hover:text-[#1D3335]"
+                                    }`}
+                                >
+                                    {t}
+                                </button>
+                            ))}
+                        </div>
+                    )}
                     <button
                         onClick={onClose}
                         className="text-[#1D3335] text-lg leading-none hover:opacity-60 cursor-pointer ml-2"
@@ -174,6 +199,10 @@ export default function StafflineViewerModal({ detection, projectId, onClose, la
                     ) : viewState.status === "error" ? (
                         <div className="flex items-center justify-center h-full text-[#1D3335]/60 text-sm">
                             {viewState.message}
+                        </div>
+                    ) : tab === "rhythm" && rhythmSummary ? (
+                        <div className="p-4">
+                            <RhythmChart summary={rhythmSummary} />
                         </div>
                     ) : (
                         <div className="p-4 flex flex-col items-center">

--- a/landing-page/src/lib/rhythmGaps.ts
+++ b/landing-page/src/lib/rhythmGaps.ts
@@ -1,0 +1,83 @@
+// Client-side reconstruction of the "gap distribution" diagnostic that
+// staff-finding/scripts/group_staves.py plots server-side (its
+// plot_gap_distribution helper, run via run_page.py) -- for stafflines run
+// through the landing-page pipeline, group_staves.py's own
+// GroupingResult.cut_threshold_px is computed but never persisted onto a
+// JsomrLineRecord (see staffline_stage.py's _assemble_jsomr_records), so
+// this recomputes an equivalent threshold from what *is* stored
+// (centerline_page.y_values, scale_unit, stave_id, rhythm_status) rather
+// than requiring a backend change. Multipliers mirror group_staves.py's own
+// MIN_GAP_MULTIPLIER / CUT_THRESHOLD_MULTIPLIER constants -- keep in sync if
+// those ever change.
+import type { JsomrLineRecord } from "../types";
+
+const MIN_GAP_MULTIPLIER = 0.5;
+const CUT_THRESHOLD_MULTIPLIER = 1.5;
+
+export interface RhythmGapBar {
+  staveId: number;
+  gapIndex: number;
+  gapPx: number;
+  isAnomalous: boolean;
+}
+
+export interface RhythmGapSummary {
+  bars: RhythmGapBar[];
+  scaleUnit: number;
+  noiseFloorPx: number;
+  cutThresholdPx: number;
+  maxInterpGapPx: number;
+}
+
+function meanY(record: JsomrLineRecord): number | null {
+  const values = record.centerline_page?.y_values;
+  if (!values || values.length === 0) return null;
+  return values.reduce((sum, y) => sum + y, 0) / values.length;
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+/** Consecutive-line-gap distribution across every stave on the page, plus
+ * the reference thresholds group_staves.py would have used to group those
+ * same lines -- null if there isn't enough data to compute anything
+ * (fewer than two lines with a known stave assignment). */
+export function computeRhythmGaps(records: JsomrLineRecord[]): RhythmGapSummary | null {
+  const byStave = new Map<number, JsomrLineRecord[]>();
+  for (const r of records) {
+    if (r.stave_id === null) continue;
+    const list = byStave.get(r.stave_id) ?? [];
+    list.push(r);
+    byStave.set(r.stave_id, list);
+  }
+  if (byStave.size === 0) return null;
+
+  const scaleUnit = records.find((r) => r.scale_unit)?.scale_unit ?? 0;
+
+  const bars: RhythmGapBar[] = [];
+  const allGaps: number[] = [];
+  for (const [staveId, lines] of byStave) {
+    const sorted = [...lines].sort(
+      (a, b) => (a.within_stave_index ?? 0) - (b.within_stave_index ?? 0),
+    );
+    const isAnomalous = sorted.some((r) => r.rhythm_status);
+    const ys = sorted.map(meanY).filter((y): y is number => y !== null);
+    for (let i = 1; i < ys.length; i++) {
+      const gapPx = Math.abs(ys[i] - ys[i - 1]);
+      allGaps.push(gapPx);
+      bars.push({ staveId, gapIndex: bars.length, gapPx, isAnomalous });
+    }
+  }
+  if (bars.length === 0) return null;
+
+  const medianGap = median(allGaps);
+  const noiseFloorPx = scaleUnit * MIN_GAP_MULTIPLIER;
+  const cutThresholdPx = Math.max(medianGap * CUT_THRESHOLD_MULTIPLIER, scaleUnit);
+  const maxInterpGapPx = Math.max(...allGaps, cutThresholdPx);
+
+  return { bars, scaleUnit, noiseFloorPx, cutThresholdPx, maxInterpGapPx };
+}

--- a/landing-page/src/types.ts
+++ b/landing-page/src/types.ts
@@ -60,6 +60,7 @@ export interface JsomrLineRecord {
   source: "detected" | "fallback_redetected" | "interpolated";
   bounding_box: { ulx: number; uly: number; lrx: number; lry: number } | null;
   centerline_page: { x_start: number; x_end: number; y_values: number[] };
+  scale_unit: number;
   stave_id: number | null;
   rhythm_status: string | null;
   within_stave_index: number | null;


### PR DESCRIPTION
## Summary
- Adds a client-side "rhythm" gap-distribution chart to `StafflineViewerModal.tsx`, reconstructing the diagnostic `group_staves.py` computes server-side (previously only visible via `run_page.py`'s own matplotlib output, never through the landing-page pipeline). No new backend storage -- computed from the already-stored JSOMR JSON.
- Closes a known gap (documented in `documentation_allons-y/STAFFLINE_INTEGRATION_FOLLOWUPS.md`): `tasks_text_batch.py`'s independent YOLO pass (backing `/text-batch/run`, the Cantus-aligned batch path) never called `staffline_stage.py`, so images processed only through it got no `staffline_detections` row. Now mirrors `tasks_predict.py`'s existing `has_class` -> `run_staffline_detection` block.

## Context
Local `main` had fallen behind `origin/main` by the whole staffline integration (staffline_stage.py, the StafflinesTab UI, etc. all already existed upstream), which is what looked like nothing was wired up. This PR is the follow-up work once synced: filling in the two real gaps that remained.

## Changes
- `landing-page/src/lib/rhythmGaps.ts` (new): per-stave consecutive-line gap computation + noise-floor/cut-threshold/max-interp-gap reference values, mirroring `group_staves.py`'s multipliers.
- `landing-page/src/components/project/RhythmChart.tsx` (new): inline-SVG bar chart rendering the above.
- `landing-page/src/components/project/StafflineViewerModal.tsx`: overlay/rhythm tab toggle.
- `landing-page/src/types.ts`: added missing `scale_unit` field to `JsomrLineRecord` (already sent by the backend, just untyped).
- `landing-page/scripts/tasks_text_batch.py`: runs staffline detection after YOLO layer-separation, same as the predict-job path.

## Verification
- `tsc --noEmit` clean.
- `eslint` on changed files: only the 2 pre-existing warnings/errors that were already there before this change (confirmed via stash diff), nothing new.
- `landing-page/scripts/tests/test_staffline_adapter.py`: 7/7 pass.
- Not yet run end-to-end through the live app (needs a real DB/Celery/browser session) -- worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Rhythm view to the staffline viewer, with charts showing spacing gaps, anomaly indicators, thresholds, and reference limits.
  * Added tabbed Overlay and Rhythm views when rhythm data is available.
  * Added rhythm-gap diagnostics based on assigned line data.

* **Bug Fixes**
  * Improved staffline detection processing and event reporting during image analysis.
  * Preserved existing annotation, masking, music-box, and progress tracking behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->