### PR TITLE
feat: changed textbox color, "raw" staffline tab, truncation/ellipses glitch, docs

### DIFF
--- a/landing-page/README.md
+++ b/landing-page/README.md
@@ -53,10 +53,8 @@ tables and how the job queue works end to end).
   redis-cli ping   # should print PONG
   ```
 
-- A **Postgres database** — this project is developed against
-  [Neon](https://neon.tech), but the backend only talks to it via a plain
-  `psycopg2` DSN, so a local Postgres install works exactly the same way.
-  If you don't already have one running:
+- A **local Postgres database** — the backend just needs a plain `psycopg2`
+  DSN, so any Postgres install works. If you don't already have one running:
 
   ```bash
   brew install postgresql@16
@@ -104,12 +102,12 @@ pip install -r requirements.txt
 Create `landing-page/scripts/.env`:
 
 ```
-DATABASE_URL=postgresql://user:password@host/dbname
+DATABASE_URL=postgresql://localhost/mothra_dev
 MOTHRA_SECRET=<any long random string>
 ```
 
 - `DATABASE_URL` is **required** — the backend fails to start without it.
-  Points at any Postgres (Neon or local, per above) — tables are created
+  Points at your local Postgres (per above) — tables are created
   automatically on first run (see `auth_api.py:init_db`).
 - `MOTHRA_SECRET` signs JWTs. If omitted, a random one is generated each
   process start, which invalidates every existing login token on restart —
@@ -303,7 +301,7 @@ git submodule update --init --recursive   # if not already done
 git lfs pull                              # medieval model .pt files are LFS pointers otherwise
 
 # create a root-level .env (gitignored, separate from landing-page/scripts/.env):
-#   DATABASE_URL=postgresql://...
+#   DATABASE_URL=postgresql://host.docker.internal/mothra_dev
 #   MOTHRA_SECRET=...
 
 docker compose build
@@ -314,8 +312,10 @@ Open **http://localhost:8001** (the backend container serves the built
 frontend directly — there's no separate `:5173` container).
 `IC_API_URL`/`TEXT_API_URL` are wired to the compose
 service names (`http://ic:8000`, `http://text-service:8002`) automatically;
-`DATABASE_URL` still points at your Postgres (Neon or otherwise) — Postgres
-itself isn't a compose service.
+Postgres itself isn't a compose service, so `DATABASE_URL` still points at
+your local Postgres install (per Prerequisites above) — from inside a
+container that means `host.docker.internal`, not `localhost`, or the
+containers won't be able to reach a Postgres running on the host machine.
 
 The `text-service` image is large (pulls in `torch`/`kraken`/`htrflow`) and
 the first `docker compose build` will take a while.

--- a/landing-page/scripts/auth_api.py
+++ b/landing-page/scripts/auth_api.py
@@ -20,6 +20,12 @@ _db_pool: Optional["_pg_pool.ThreadedConnectionPool"] = None
 def _get_pool() -> "_pg_pool.ThreadedConnectionPool":
     global _db_pool
     if _db_pool is None:
+        # Bare os.environ[...] -- raises KeyError, not a friendly error, if
+        # landing-page/scripts/.env doesn't exist/doesn't set this yet.
+        # psycopg2 just needs a DSN, so any local Postgres works -- see
+        # ../README.md's "Prerequisites" section for the install
+        # (brew install postgresql@16 && createdb mothra_dev, then
+        # DATABASE_URL=postgresql://localhost/mothra_dev).
         _db_pool = _pg_pool.ThreadedConnectionPool(
             minconn=2, maxconn=15, dsn=os.environ["DATABASE_URL"]
         )

--- a/landing-page/src/components/project/AnnotationViewerModal.tsx
+++ b/landing-page/src/components/project/AnnotationViewerModal.tsx
@@ -17,7 +17,21 @@ type ViewState =
     | { status: "error"; message: string }
     | { status: "ready"; imageUrl: string; boxes: BBox[]; rawYolo: string };
 
-const PALETTE = ["#4AADAA", "#FFA500", "#E87BF7", "#F76B6B", "#6BF7A5", "#F7E16B"];
+// cls indices follow the merged 0=text/1=music/2=staves slot convention
+// documented in medieval_models.py / yolo_inference.py's CATEGORY_TO_SLOT —
+// true for both the medieval preset and any custom model with a class map.
+// Text gets the same bright pink as TextAlignmentViewerModal's syllable
+// boxes; stave boxes aren't drawn here at all (filtered out in drawOverlay
+// below) since they're redundant with the dedicated staffline viewer.
+const TEXT_COLOR = "#f03ad7";
+const MUSIC_COLOR = "#FFA500";
+const OTHER_COLORS = ["#F76B6B", "#6BF7A5", "#F7E16B"];
+
+function colorForClass(cls: number): string {
+    if (cls === 0) return TEXT_COLOR;
+    if (cls === 1) return MUSIC_COLOR;
+    return OTHER_COLORS[cls % OTHER_COLORS.length];
+}
 
 function parseYolo(txt: string): BBox[] {
     return txt
@@ -93,18 +107,20 @@ export default function AnnotationViewerModal({ set, projectId, onClose }: Props
         const ctx = canvas.getContext("2d")!;
         ctx.scale(MAX_SCALE, MAX_SCALE);
         ctx.clearRect(0, 0, dw, dh);
-        viewState.boxes.forEach((b) => {
-            const color = PALETTE[b.cls % PALETTE.length];
-            const x = (b.cx - b.bw / 2) * dw;
-            const y = (b.cy - b.bh / 2) * dh;
-            const w = b.bw * dw;
-            const h = b.bh * dh;
-            ctx.fillStyle = color + "20";
-            ctx.strokeStyle = color;
-            ctx.lineWidth = 0.75;
-            ctx.fillRect(x, y, w, h);
-            ctx.strokeRect(x, y, w, h);
-        });
+        viewState.boxes
+            .filter((b) => b.cls !== 2) // staves — not shown in this viewer
+            .forEach((b) => {
+                const color = colorForClass(b.cls);
+                const x = (b.cx - b.bw / 2) * dw;
+                const y = (b.cy - b.bh / 2) * dh;
+                const w = b.bw * dw;
+                const h = b.bh * dh;
+                ctx.fillStyle = color + "20";
+                ctx.strokeStyle = color;
+                ctx.lineWidth = 0.75;
+                ctx.fillRect(x, y, w, h);
+                ctx.strokeRect(x, y, w, h);
+            });
     }, [viewState]);
 
     useEffect(() => {

--- a/landing-page/src/components/project/MyProjects.tsx
+++ b/landing-page/src/components/project/MyProjects.tsx
@@ -493,7 +493,9 @@ export default function MyProjects({
                   key={p.id}
                   className={`grid ${TRASH_COLS} px-6 py-4 border-b border-[#1D3335]/10 last:border-0 items-center text-[#1D3335] text-sm`}
                 >
-                  <span className="opacity-60">{p.name}</span>
+                  <span className="opacity-60 min-w-0">
+                    <TruncatedName name={p.name} />
+                  </span>
                   <span className="opacity-60">{p.user}</span>
                   <span className="opacity-60">{daysLeft}d</span>
                   <div className="flex justify-end gap-3">

--- a/landing-page/src/components/project/MyProjects.tsx
+++ b/landing-page/src/components/project/MyProjects.tsx
@@ -8,6 +8,7 @@ import DeleteProjectModal from "./DeleteProjectModal";
 import LargeImageWarningModal from "./LargeImageWarningModal";
 import { formatLastOpened } from "../../utils/time";
 import Modal from "../shared/Modal";
+import TruncatedName from "../shared/TruncatedName";
 
 const LIST_COLS = "grid-cols-[2fr_1fr_1fr_5rem]";
 const TRASH_COLS = "grid-cols-[2fr_2fr_1fr_8rem]";
@@ -318,17 +319,17 @@ export default function MyProjects({
                         className="bg-white rounded-lg px-3 py-1 text-[#1D3335] outline-none text-sm w-2/3"
                       />
                     ) : (
-                      <div className="flex flex-col">
-                        <div className="flex items-center gap-1.5">
+                      <div className="flex flex-col min-w-0">
+                        <div className="flex items-center gap-1.5 min-w-0">
                           <PinButton
                             isPinned={!!p.isPinned}
                             onToggle={() => onTogglePin(p.id)}
                           />
                           <span
                             onClick={() => onSelectProject(p.id)}
-                            className="cursor-pointer hover:underline"
+                            className="cursor-pointer hover:underline min-w-0"
                           >
-                            {p.name}
+                            <TruncatedName name={p.name} />
                           </span>
                         </div>
                         <MeiProgress meiFiles={p.meiFiles} />
@@ -403,14 +404,15 @@ export default function MyProjects({
                           )}
                         </div>
                         <div className="p-3 flex flex-col gap-1">
-                          <div className="flex items-center gap-1.5">
+                          <div className="flex items-center gap-1.5 min-w-0">
                             <PinButton
                               isPinned={!!p.isPinned}
                               onToggle={() => onTogglePin(p.id)}
                             />
-                            <span className="font-semibold text-[#1D3335] text-sm truncate">
-                              {p.name}
-                            </span>
+                            <TruncatedName
+                              name={p.name}
+                              className="font-semibold text-[#1D3335] text-sm"
+                            />
                           </div>
                           <span className="text-[#1D3335]/50 text-xs">
                             {formatLastOpened(p.lastOpenedAt)}

--- a/landing-page/src/components/project/ProjectDetail.tsx
+++ b/landing-page/src/components/project/ProjectDetail.tsx
@@ -253,14 +253,14 @@ export default function ProjectDetail({
     <>
       <button
         onClick={onUse}
-        className="ml-2 px-5 border-2 border-white text-white text-sm rounded-full hover:opacity-90 cursor-pointer bg-white/20"
+        className="px-5 border-2 border-white text-white text-sm rounded-full hover:opacity-90 cursor-pointer bg-white/20 shrink-0 whitespace-nowrap"
       >
         use {count} {noun}
         {count > 1 ? "s" : ""}
       </button>
       <button
         onClick={onDelete}
-        className="px-5 border-2 border-white text-white text-sm rounded-full hover:opacity-90 cursor-pointer bg-white/20"
+        className="px-5 border-2 border-white text-white text-sm rounded-full hover:opacity-90 cursor-pointer bg-white/20 shrink-0 whitespace-nowrap"
       >
         delete {count} {noun}
         {count > 1 ? "s" : ""}
@@ -336,17 +336,17 @@ export default function ProjectDetail({
 
         <div className="flex-1 min-w-0">
           {/* header */}
-          <div className="flex items-center gap-4 mb-8">
+          <div className="flex items-center gap-4 mb-3">
             <button
               onClick={onBack}
-              className="text-white text-2xl hover:opacity-70 transition-opacity cursor-pointer"
+              className="text-white text-2xl hover:opacity-70 transition-opacity cursor-pointer shrink-0"
             >
               ←
             </button>
-            <h1 className="text-4xl font-bold italic text-white">
-              {project.name}
+            <h1 className="text-4xl font-bold italic text-white min-w-0 shrink">
+              <TruncatedName name={project.name} />
             </h1>
-            <div className="relative">
+            <div className="relative shrink-0">
               <button
                 onClick={() => setProjectMenu((v) => !v)}
                 className="text-white text-2xl hover:opacity-70 cursor-pointer leading-none"
@@ -383,18 +383,21 @@ export default function ProjectDetail({
                 </>
               )}
             </div>
+          </div>
 
+          {/* action buttons — on their own row so a long project name never crowds them out */}
+          <div className="flex items-center gap-3 flex-wrap mb-8">
             {activeTab === "images" ? (
               <button
                 onClick={() => imgSection.setUploadModal(true)}
-                className="ml-4 px-5 border-2 border-white text-white text-sm rounded-full hover:opacity-90 cursor-pointer"
+                className="px-5 border-2 border-white text-white text-sm rounded-full hover:opacity-90 cursor-pointer shrink-0"
               >
                 + new image
               </button>
             ) : activeTab === "models" ? (
               <button
                 onClick={() => mdlSection.setUploadModal(true)}
-                className="ml-4 px-5 border-2 border-white text-white text-sm rounded-full hover:opacity-90 cursor-pointer"
+                className="px-5 border-2 border-white text-white text-sm rounded-full hover:opacity-90 cursor-pointer shrink-0"
               >
                 + upload model
               </button>
@@ -497,7 +500,7 @@ export default function ProjectDetail({
                         .filter((a) => annSection.selectedIds.has(a.id))
                         .forEach((a) => onDownloadAnnotation(a.id, "txt"))
                     }
-                    className="px-5 border-2 border-white text-white text-sm rounded-full hover:opacity-90 cursor-pointer bg-white/20"
+                    className="px-5 border-2 border-white text-white text-sm rounded-full hover:opacity-90 cursor-pointer bg-white/20 shrink-0 whitespace-nowrap"
                   >
                     download {annSection.selectedIds.size > 1 ? `${annSection.selectedIds.size} ` : ""}annotation{annSection.selectedIds.size > 1 ? "s" : ""} (.txt)
                   </button>
@@ -507,7 +510,7 @@ export default function ProjectDetail({
                         .filter((a) => annSection.selectedIds.has(a.id))
                         .forEach((a) => onDownloadAnnotation(a.id, "json"))
                     }
-                    className="px-5 border-2 border-white text-white text-sm rounded-full hover:opacity-90 cursor-pointer bg-white/20"
+                    className="px-5 border-2 border-white text-white text-sm rounded-full hover:opacity-90 cursor-pointer bg-white/20 shrink-0 whitespace-nowrap"
                   >
                     download {annSection.selectedIds.size > 1 ? `${annSection.selectedIds.size} ` : ""}annotation{annSection.selectedIds.size > 1 ? "s" : ""} (.json)
                   </button>
@@ -526,7 +529,7 @@ export default function ProjectDetail({
                           ),
                         )
                     }
-                    className="ml-2 px-5 border-2 border-white text-white text-sm rounded-full hover:opacity-90 cursor-pointer bg-white/20"
+                    className="px-5 border-2 border-white text-white text-sm rounded-full hover:opacity-90 cursor-pointer bg-white/20 shrink-0 whitespace-nowrap"
                   >
                     download {meiSection.selectedIds.size} mei file{meiSection.selectedIds.size > 1 ? "s" : ""}
                   </button>
@@ -541,7 +544,7 @@ export default function ProjectDetail({
                         meiFiles: project.meiFiles.filter((f) => !deleted.has(f.id)),
                       });
                     }}
-                    className="ml-2 px-5 border-2 border-white text-white text-sm rounded-full hover:opacity-90 cursor-pointer bg-white/20"
+                    className="px-5 border-2 border-white text-white text-sm rounded-full hover:opacity-90 cursor-pointer bg-white/20 shrink-0 whitespace-nowrap"
                   >
                     delete {meiSection.selectedIds.size} mei file{meiSection.selectedIds.size > 1 ? "s" : ""}
                   </button>

--- a/landing-page/src/components/project/ProjectDetail.tsx
+++ b/landing-page/src/components/project/ProjectDetail.tsx
@@ -269,7 +269,7 @@ export default function ProjectDetail({
   );
 
   return (
-    <div className="animate-fade-in flex-1 bg-[#4AADAA] px-6 pt-10 pb-48 relative">
+    <div className="animate-fade-in flex-1 bg-[#4AADAA] px-6 pt-10 pb-48 relative overflow-x-auto">
       <div
         className={`absolute inset-0 z-30 bg-black/30 transition-opacity pointer-events-none
           ${imgSection.uploadModal || !!imgSection.renameModal || mdlSection.uploadModal || !!mdlSection.renameModal ? "opacity-100" : "opacity-0"}`}
@@ -334,7 +334,7 @@ export default function ProjectDetail({
           </div>
         </div>
 
-        <div className="flex-1 min-w-0">
+        <div className="flex-1">
           {/* header */}
           <div className="flex items-center gap-4 mb-3">
             <button

--- a/landing-page/src/components/project/StafflineViewerModal.tsx
+++ b/landing-page/src/components/project/StafflineViewerModal.tsx
@@ -7,7 +7,7 @@ import RhythmChart from "./RhythmChart";
 type ViewState =
     | { status: "loading" }
     | { status: "error"; message: string }
-    | { status: "ready"; imageUrl: string; records: JsomrLineRecord[] };
+    | { status: "ready"; imageUrl: string; records: JsomrLineRecord[]; prettyJson: string };
 
 // Matches AnnotationViewerModal's class-color palette, extended here to
 // color-code by stave_id instead of YOLO class -- keeps the "index into a
@@ -26,9 +26,36 @@ interface Props {
 export default function StafflineViewerModal({ detection, projectId, onClose, label }: Props) {
     const [viewState, setViewState] = useState<ViewState>({ status: "loading" });
     const [notesOpen, setNotesOpen] = useState(false);
-    const [tab, setTab] = useState<"overlay" | "rhythm">("overlay");
+    const [tab, setTab] = useState<"overlay" | "rhythm" | "raw">("overlay");
+    const [copied, setCopied] = useState(false);
+    const [copyFailed, setCopyFailed] = useState(false);
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const imgRef = useRef<HTMLImageElement>(null);
+
+    const handleCopyText = (text: string) => {
+        navigator.clipboard
+            .writeText(text)
+            .then(() => setCopied(true))
+            .catch(() => setCopyFailed(true))
+            .finally(() => {
+                setTimeout(() => {
+                    setCopied(false);
+                    setCopyFailed(false);
+                }, 1500);
+            });
+    };
+
+    const handleDownload = (text: string, extension: string, mimeType = "text/plain;charset=utf-8") => {
+        const blob = new Blob([text], { type: mimeType });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = `${(label ?? detection.imageName).replace(/\.[^.]+$/, "")}.${extension}`;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(url);
+    };
 
     const rhythmSummary = useMemo(
         () => (viewState.status === "ready" ? computeRhythmGaps(viewState.records) : null),
@@ -119,11 +146,15 @@ export default function StafflineViewerModal({ detection, projectId, onClose, la
                     URL.revokeObjectURL(imageUrl);
                     return;
                 }
+                // jsomrJson is a native array (JSONB column) -- no JSON.parse needed.
+                const records = (data as { jsomrJson: JsomrLineRecord[] }).jsomrJson ?? [];
                 setViewState({
                     status: "ready",
                     imageUrl,
-                    // jsomrJson is a native array (JSONB column) -- no JSON.parse needed.
-                    records: (data as { jsomrJson: JsomrLineRecord[] }).jsomrJson ?? [],
+                    records,
+                    // Pretty-printed purely for the "raw" tab's readability, same
+                    // as TextAlignmentViewerModal's prettyJson.
+                    prettyJson: JSON.stringify(records, null, 2),
                 });
             })
             .catch(() => {
@@ -167,21 +198,23 @@ export default function StafflineViewerModal({ detection, projectId, onClose, la
                             {anomalousStaveIds.size} flagged for review
                         </span>
                     )}
-                    {viewState.status === "ready" && rhythmSummary && (
+                    {viewState.status === "ready" && (
                         <div className="flex bg-[#1D3335]/10 rounded-full p-0.5 text-xs font-mono">
-                            {(["overlay", "rhythm"] as const).map((t) => (
-                                <button
-                                    key={t}
-                                    onClick={() => setTab(t)}
-                                    className={`px-3 py-1 rounded-full cursor-pointer transition-colors ${
-                                        tab === t
-                                            ? "bg-[#1D3335] text-white"
-                                            : "text-[#1D3335]/60 hover:text-[#1D3335]"
-                                    }`}
-                                >
-                                    {t}
-                                </button>
-                            ))}
+                            {(rhythmSummary ? (["overlay", "rhythm", "raw"] as const) : (["overlay", "raw"] as const)).map(
+                                (t) => (
+                                    <button
+                                        key={t}
+                                        onClick={() => setTab(t)}
+                                        className={`px-3 py-1 rounded-full cursor-pointer transition-colors ${
+                                            tab === t
+                                                ? "bg-[#1D3335] text-white"
+                                                : "text-[#1D3335]/60 hover:text-[#1D3335]"
+                                        }`}
+                                    >
+                                        {t}
+                                    </button>
+                                ),
+                            )}
                         </div>
                     )}
                     <button
@@ -203,6 +236,26 @@ export default function StafflineViewerModal({ detection, projectId, onClose, la
                     ) : tab === "rhythm" && rhythmSummary ? (
                         <div className="p-4">
                             <RhythmChart summary={rhythmSummary} />
+                        </div>
+                    ) : tab === "raw" ? (
+                        <div className="p-4">
+                            <div className="flex items-center justify-end gap-3 mb-2">
+                                <button
+                                    onClick={() => handleDownload(viewState.prettyJson, "json", "application/json")}
+                                    className="text-xs font-mono text-[#1D3335]/60 hover:text-[#1D3335] cursor-pointer"
+                                >
+                                    download
+                                </button>
+                                <button
+                                    onClick={() => handleCopyText(viewState.prettyJson)}
+                                    className="text-xs font-mono text-[#1D3335]/60 hover:text-[#1D3335] cursor-pointer"
+                                >
+                                    {copyFailed ? "copy failed" : copied ? "copied" : "copy"}
+                                </button>
+                            </div>
+                            <pre className="bg-[#1D3335] text-white/80 text-xs font-mono rounded-xl p-4 overflow-auto h-[min(65vh,650px)] whitespace-pre">
+                                {viewState.prettyJson}
+                            </pre>
                         </div>
                     ) : (
                         <div className="p-4 flex flex-col items-center">

--- a/landing-page/src/components/project/TextAlignmentViewerModal.tsx
+++ b/landing-page/src/components/project/TextAlignmentViewerModal.tsx
@@ -15,7 +15,8 @@ type ViewState =
     | { status: "error"; message: string }
     | { status: "ready"; imageUrl: string; boxes: SylBox[]; logText: string; prettyJson: string };
 
-const BOX_COLOR = "#4AADAA";
+
+const BOX_COLOR = "#e809ca";
 
 interface Props {
     alignment: TextAlignment;
@@ -150,22 +151,34 @@ export default function TextAlignmentViewerModal({ alignment, projectId, onClose
         const ctx = canvas.getContext("2d")!;
         ctx.scale(MAX_SCALE, MAX_SCALE);
         ctx.clearRect(0, 0, dw, dh);
-        // Divided by the *current* zoom (not MAX_SCALE) so the label stays a
-        // roughly constant, legible on-screen size instead of growing right
-        // along with the (now-crisp) boxes and overlapping its neighbors —
-        // box outlines are still meant to visibly grow when zoomed in, only
-        // the text needs to stay put.
-        const fontPx = 11 / zoom.scale;
-        const labelYFloor = 10 / zoom.scale;
+        // Divided by sqrt(current zoom), not the current zoom outright, so the
+        // label grows only partway toward matching the (now-crisp) boxes —
+        // fully compensating the CSS transform (dividing by zoom.scale)
+        // pinned the label at a constant ~13px on screen at every zoom
+        // level, which read as too small once zoomed in a long way. This
+        // still damps growth relative to the boxes themselves (so labels
+        // don't balloon and overlap their neighbors) while letting them
+        // actually get more legible as you zoom in.
+        const fontPx = 10 / Math.sqrt(zoom.scale);
+        const labelYFloor = fontPx * 1.1;
         viewState.boxes.forEach((b, i) => {
             const { x, y, w, h } = boxScreenRect(b, scaleX, scaleY);
             const hovered = i === hoveredBoxIndex;
-            ctx.fillStyle = BOX_COLOR + (hovered ? "45" : "20");
-            ctx.strokeStyle = hovered ? "#1D3335" : BOX_COLOR;
+            // Non-hovered border/label get alpha (not the fully opaque
+            // BOX_COLOR) — at full opacity, a neon-bright stroke drawn right
+            // through every letter's ascenders/descenders (boxes butt up
+            // against each other across the whole line) reads as glare and
+            // fights the manuscript's own ink for attention. Translucent —
+            // like an actual highlighter pen — keeps the mark visible
+            // without drowning out the text it's marking. Hover stays
+            // solid/dark since it's a deliberate, momentary emphasis, not
+            // the resting state the eye has to read through.
+            ctx.fillStyle = BOX_COLOR + (hovered ? "45" : "14");
+            ctx.strokeStyle = hovered ? "#910c80" : BOX_COLOR + "80";
             ctx.lineWidth = hovered ? 1.25 : 0.75;
             ctx.fillRect(x, y, w, h);
             ctx.strokeRect(x, y, w, h);
-            ctx.fillStyle = hovered ? "#1D3335" : BOX_COLOR;
+            ctx.fillStyle = hovered ? "#910c80" : BOX_COLOR + "cc";
             ctx.font = `${hovered ? "bold " : ""}${fontPx}px monospace`;
             ctx.fillText(b.syl, x, Math.max(labelYFloor, y - 2));
         });
@@ -371,9 +384,12 @@ export default function TextAlignmentViewerModal({ alignment, projectId, onClose
                                     <button
                                         onClick={() => setTextPanelOpen((o) => !o)}
                                         title={textPanelOpen ? "Hide plain text" : "Show plain text"}
-                                        className="shrink-0 w-6 flex items-center justify-center bg-[#1D3335]/10 hover:bg-[#1D3335]/20 rounded-l-lg text-[#1D3335] text-xs cursor-pointer select-none"
+                                        className="shrink-0 w-6 flex flex-col items-center justify-center gap-2 bg-[#1D3335]/10 hover:bg-[#1D3335]/20 rounded-l-lg text-[#1D3335] cursor-pointer select-none"
                                     >
-                                        {textPanelOpen ? "›" : "‹"}
+                                        <span className="[writing-mode:vertical-rl] rotate-180 text-[10px] font-mono tracking-wide">
+                                            view text
+                                        </span>
+                                        <span className="text-xs">{textPanelOpen ? "›" : "‹"}</span>
                                     </button>
                                     {textPanelOpen && (() => {
                                         const lines =
@@ -408,7 +424,7 @@ export default function TextAlignmentViewerModal({ alignment, projectId, onClose
                                                                         <span
                                                                             className={
                                                                                 tok.index === hoveredBoxIndex
-                                                                                    ? "bg-[#4AADAA]/50 rounded px-0.5"
+                                                                                    ? "bg-[#06B6D4]/50 rounded px-0.5"
                                                                                     : ""
                                                                             }
                                                                         >

--- a/landing-page/src/components/shared/TruncatedName.tsx
+++ b/landing-page/src/components/shared/TruncatedName.tsx
@@ -45,7 +45,16 @@ export default function TruncatedName({
           {head}
         </span>
       )}
-      <span className="min-w-0 max-w-full overflow-hidden text-ellipsis whitespace-nowrap shrink-0">
+      {/* No `max-w-full` here (issue #130, round 2) — `max-width` is applied
+          as a hard clamp before the flex-shrink algorithm runs, so it was
+          silently overriding `shrink-0` the instant this row got narrower
+          than the tail's own text: the tail — the one part meant to *always*
+          stay fully visible — got squeezed down and re-ellipsized by its own
+          `text-ellipsis`, on top of whatever the head was already doing.
+          Dropping it lets `shrink-0` actually hold; if there's truly no room
+          for both, the outer span's `overflow-hidden` clips a plain sliver
+          off the tail's end instead of re-truncating it into a garbled mess. */}
+      <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap shrink-0">
         {tail}
         {suffix}
       </span>


### PR DESCRIPTION
refs: #130, #155, #139, #158

- textbox is now pink, text size should be larger when zoomed in for readability; sidebar tab also has a label so users know that it shows the syllables
- raw staffline tab to view/download the json
- attempted fix at the ellipses/truncation glitch
- updated documentation to be more explicit about the local postgres db setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a raw data view to staffline results, with formatted JSON, copy, and download controls.
  * Added clearer tab availability when rhythm data is unavailable.

* **Bug Fixes**
  * Improved annotation colours and excluded unsupported stave boxes.
  * Enhanced text overlay readability, hover highlighting, and zoom scaling.
  * Improved long-name truncation to preserve visible trailing text.

* **Documentation**
  * Updated local database setup and Docker connection instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->