### PR TITLE
Interpolation preview/accept for flagged staves + stave-source verification + bbox tracing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,10 +37,12 @@ jobs:
         with:
           python-version: "3.11"
 
-      # Pillow: only thing staffline_adapter.py's own import chain
-      # (encode_to_mei.py) needs beyond stdlib + the staff-finding package.
+      # Pillow: staffline_adapter.py's own import chain (encode_to_mei.py)
+      # needs it beyond stdlib + the staff-finding package. PyYAML: pulled
+      # in transitively by test_bbox_pipeline_integrity.py's medieval_models
+      # import (medieval_models.py -> config.py, which loads config.yaml).
       - name: Install dependencies
-        run: pip install -e "./staff-finding[diagnostics]" pytest Pillow
+        run: pip install -e "./staff-finding[diagnostics]" pytest Pillow PyYAML
 
       - name: staff-finding -- scripts/test_group_staves.py
         working-directory: staff-finding
@@ -71,8 +73,8 @@ jobs:
         working-directory: staff-finding
         run: python -m pytest scripts/script_tests/test_run_pageOG.py
 
-      - name: landing-page -- staffline_adapter tests
-        run: python -m pytest landing-page/scripts/tests/test_staffline_adapter.py
+      - name: landing-page -- DB-independent scripts tests
+        run: python -m pytest landing-page/scripts/tests/
 
   # Type-checks the landing-page frontend on every branch push. Before this
   # job existed, nothing compiled TypeScript until `npm run build` ran inside

--- a/README.md
+++ b/README.md
@@ -1,415 +1,164 @@
-# Mothra 🦋
+# Mothra
 
 **YOLO-based Optical Music Recognition for Medieval Manuscripts**
 
-A research project exploring whether YOLO object detection can outperform our traditional OMR pipeline (Rodan) for medieval musical manuscript analysis, with a custom web-based annotation tool for rapid dataset creation.
+A DDMAL (McGill) research project exploring whether YOLO object detection can outperform
+the traditional OMR pipeline (Rodan) for medieval musical manuscript analysis — from raw
+manuscript image, through human-in-the-loop correction, to a corrected MEI file ready for
+Cantus Ultimus.
 
-The website exists here: https://mothra.simssa.ca/.
+The live site: https://mothra.simssa.ca/.
 
----
-
-## Project Overview
-
-Mothra is an experimental (eventual) OMR system that applies modern object detection techniques (YOLO) to the challenging domain of medieval music manuscripts. The project consists of two main components:
-
-1. **YOLO OMR Pipeline** - Machine learning experiments using DocLayout-YOLO for manuscript layout analysis
-2. **Mothra Annotator** - Browser-based bounding box annotation tool for creating training datasets
-
-### Why "Mothra"?
-
-This project challenges the existing [Rodan](https://github.com/DDMAL/Rodan) workflow engine (kaiju fight, anyone? 🦖 vs 🦋). Where Rodan uses traditional document analysis and segmentation pipelines, Mothra explores whether end-to-end deep learning can successfully execute OMR based from object detection.
+> **New here?** [`CLAUDE.md`](CLAUDE.md) is the up-to-date technical reference for the
+> web app (architecture, local setup, deployment). This README is the map of the whole
+> project and how its pieces fit together; `CLAUDE.md` is where you go once you're
+> working in `landing-page/`.
 
 ---
 
-## Research Context
-### Research Questions
+## Why "Mothra"?
 
-1. Can YOLO detect manuscript layout elements (text, staves, neumes) more robustly than pixel-level methods?
-2. Does DocLayout-YOLO's synthetic data generation translate to parchment patterns?
-3. Can object detection provide a faster annotation → training → inference cycle than traditional (CNN-/deparation)OMR?
-4. How does overlapping box detection (neumes on staves) perform vs. segmentation approaches?
+This project challenges the existing [Rodan](https://github.com/DDMAL/Rodan) workflow
+engine (kaiju fight, anyone?). Where Rodan uses a multi-stage, pixel-level
+document analysis and segmentation pipeline, Mothra explores whether end-to-end deep
+learning object detection can drive OMR instead — trading some interpretability for
+speed and a simpler annotation → training → inference cycle.
 
 ---
 
-## Repository Structure
-Assume the branch is `main` unless otherwise specified.
+## What's live today
+
+The center of gravity of this repo is **[`landing-page/`](landing-page/)** — a full
+web application (React + FastAPI + Celery + Postgres) that carries a manuscript through
+the whole pipeline:
+
+```
+upload images → Interactive Classifier (IC) → encode to MEI → Neon.js correction → export for Cantus Ultimus
+```
+
+YOLO models detect text/music/stave regions; a dedicated staffline-detection stage fits
+and groups stave lines; a text-finding service (HTR) locates chant text; the Interactive
+Classifier is where a human corrects and classifies neume detections; the result is
+encoded to MEI and hand-corrected in an embedded Neon.js editor before being bundled for
+manual hand-off into Cantus Ultimus.
+
+**To run it locally:**
+
+```bash
+git submodule update --init --recursive   # pulls in ic/, mothra-text/, landing-page/neon
+./dev.sh                                  # starts all five services together
+```
+
+See [`CLAUDE.md`](CLAUDE.md) for the full architecture, manual per-service startup,
+configuration, Docker/Kubernetes deployment, and database schema — that file is kept
+current as the app evolves and is the source of truth, not this section.
+
+---
+
+## The ecosystem
+
+Mothra isn't one codebase — related pieces live as sub-packages in this repo, as git
+submodules, as sibling DDMAL repos, and as active-but-unmerged branches. Here's the map:
+
+| Piece | What it does | Where it lives |
+|---|---|---|
+| **Landing page** | The web app tying the whole pipeline together | [`landing-page/`](landing-page/) (this repo) |
+| **Staffline detection** | Component filtering → centerline fitting → stave grouping on YOLO stave boxes | [`staff-finding/`](staff-finding/) (this repo, pip-installed by `landing-page/`) — see its [status doc](staff-finding/dox/STATUS.md) |
+| **Text-finding** | Kraken/HTR pipeline that locates and reads chant text on the page | [`text-service/`](text-service/) (this repo) wraps the [`mothra-text`](https://github.com/DDMAL/mothra-text) submodule |
+| **Interactive Classifier (IC)** | Human-in-the-loop correction of detections, including neume classification | [`ic/`](ic/) submodule → [DDMAL/Standalone-Interactive-Classifier](https://github.com/DDMAL/Standalone-Interactive-Classifier) |
+| **Pitch finding** | Turning stave + neume detections into actual pitches | not in this repo — [DDMAL/Standalone-Pitch-Finder](https://github.com/DDMAL/Standalone-Pitch-Finder) |
+| **Mothra Print** | Running the pipeline on printed (not manuscript) chant books, starting with the Liber Usualis | inference artifacts in [`inference-outputs/liber_usualis_print/`](inference-outputs/liber_usualis_print/); in final tweaks for a Cantus Ultimus music-search upload |
+| **paco-classifier integration** *(in progress, unmerged)* | An alternate/experimental staffline-detection classifier being wired in as its own service | branch [`gianna/calvo-integration`](https://github.com/DDMAL/mothra/tree/gianna/calvo-integration) |
+| **Mothra Annotator** | Browser-based bounding-box annotation tool for building YOLO training data | now hosted externally at https://ddmal.ca/mothra-annotator/ (no longer part of this repo) |
+
+Pitch finding and the IC's neume classification are deliberately out-of-repo — they're
+developed and versioned as their own standalone tools rather than folded into
+`landing-page/`.
+
+---
+
+## Repository layout
+
 ```
 mothra/
-├── README.md                 # This file
-├── annotator/                # Web-based annotation tool
-│   ├── index.html           # BRANCH: `mothra-ghpages` Main annotator interface
-│   ├── annotator.js         # BRANCH: `mothra-ghpages` Core annotation logic
-│   ├── annotate_yolo.py     # Locally run YOLO annotation tool
-│   ├── README.md            # Details on how to clone, YOLO annotation requirements, and how to move annotations forward for splitting
-│   ├── SAMPLE_WORKFLOW.md   # Sample head-to-tail annotation workflow
-│   ├── setup.sh             # Bash script for running the annotator using ios
-│   ├── setup.bat            # Bash script for running the annotator using windows
-│   ├── QUICK_REFERENCE.md   # Annotation guide 
-│   └── THEME_NOTES.md       # Design documentation
-├── data/                     # Datasets (gitignored)
-│   ├── raw/                 # Original manuscript images
-│   ├── annotations/         # JSON and YOLO format labels
-│   └── splits/              # Train/val/test splits
-├── samples/                 # Sample images of a fully annotated image in mothra-annotator, a correct YOLO.txt file, and a screenshot of the complete UI
-├── experiments/              # YOLO training experiments
-│   ├── doclayout-yolo/      # DocLayout-YOLO implementation
-│   ├── configs/             # Training configurations
-│   └── results/             # Model outputs, metrics
-├── scripts/                  # Utility scripts
-│   ├── convert_to_yolo.py   # JSON → YOLO format converter
-│   └── split_dataset.py     # Manuscript-aware data splitting
-└── allons-y/                     # Additional documentation
-    ├── ANNOTATION_GUIDE.md  # How to annotate manuscripts
-    ├── PLAN.md              # Central team docs for phases of process, needs, and questions
-    └── ARCHITECTURE.md      # Technical decisions & comparisons
+├── README.md                    # This file
+├── CLAUDE.md                    # Technical reference for landing-page/ (architecture, setup, deployment)
+├── landing-page/                # The live web app (React + FastAPI + Celery + Postgres)
+│   ├── scripts/                 # FastAPI backend, Celery tasks
+│   ├── src/                     # React frontend
+│   ├── neon/                    # Neon.js MEI editor (submodule)
+│   └── ...
+├── staff-finding/                # Staffline detection module (pip-installable, used by landing-page)
+│   └── dox/                     # Design notes, status, pitch-finding notes
+├── ic/                           # Interactive Classifier (submodule)
+├── mothra-text/                  # Text-finding pipeline used by text-service/ (submodule)
+├── text-service/                 # FastAPI wrapper around mothra-text
+├── k8s/                          # Kubernetes manifests for deployment
+├── docker-compose.yml            # Local multi-container stack (mirrors k8s/)
+├── OLD-annotator/                 # Legacy local annotation script — superseded by the hosted annotator, kept for reference only
+├── documentation_allons-y/        # Project notes: original brief, staff-finding integration follow-ups, WIP docs
+├── configs/                       # YOLO training configs (original layout-detection experiments)
+├── data/                          # Manuscript images/annotations for the YOLO layout-detection experiments (gitignored where large)
+└── scripts/                       # Standalone training/inference/conversion scripts for the above experiments
 ```
 
----
-
-## Part 1: Mothra Annotator
-
-A browser-based tool for creating YOLO training data. Designed for speed and precision when annotating hundreds of manuscript pages.
-Lives on the branch `mothra-ghpages`, inside `mothra/annotator`.
-
-### Features
-
-- **Three-class annotation**: Text regions, music systems, staff lines
-- **Zoom & pan**: Up to 500% zoom for tiny neumes
-- **Opacity controls**: Adjust box transparency to see underlying content
-- **Label toggle**: Hide labels when they obscure details
-- **Multiple export formats**: JSON, YOLO .txt, or both
-- **Keyboard shortcuts**: Rapid annotation workflow
-- **Client-side processing**: Zero backend required, runs entirely in browser
-- **Session persistence**: Annotations saved in browser storage
-
-### Quick Start (Annotator)
-User annotators may proceed to **Annotation Workflow**. This documentation covers the available options for hosting and deploying the Mothra Annotator tool.
-
-#### Option 1: GitHub Pages (Recommended for Collaborators)
-
-1. **Deploy to GitHub Pages:**
-   ```bash
-   cd mothra
-   git checkout --orphan mothra-ghpages
-   git rm -rf .
-   cp annotator/index.html annotator/annotator.js .
-   git add index.html annotator.js
-   git commit -m "Deploy annotation tool"
-   git push origin mothra-ghpages
-   ```
-
-2. **Enable Pages:**
-   - Go to Settings → Pages
-   - Source: `mothra-ghpages` branch, `/ (root)` folder
-   - Access at: `https://USERNAME.github.io/mothra/`
-
-3. **Share with annotators** - they just need the URL, no installation required
-
-#### Option 2: Local Development
-
-```bash
-cd annotator
-python3 -m http.server 8000
-# Open http://localhost:8000 in browser
-```
-
-### Annotation Workflow
-
-1. **Load image**: Click "Choose File" or drag & drop
-2. **Select class**: Press `1` (text), `2` (music), or `3` (staves)
-3. **Draw boxes**: Click and drag on canvas
-4. **Zoom for precision**: Use `+`/`-` keys or Ctrl+wheel
-5. **Adjust visibility**: Toggle labels and opacity as needed
-6. **Download**: Press `Z` for both JSON and YOLO formats
-
-**Pro Tips:**
-- Zoom in to 300-500% for tiny neumes
-- Use Shift+drag to pan when zoomed
-- Lower opacity to 30-50% when checking coverage
-- Use manuscript-aware splits (don't mix pages from same manuscript across train/val)
-
-### Output Formats
-
-**JSON** (session backup, human-readable):
-```json
-{
-  "image_path": "AM_194_8vo_01r.png",
-  "image_width": 2400,
-  "image_height": 3200,
-  "annotations": [
-    {
-      "class_id": 2,
-      "class_name": "music",
-      "bbox": [120, 450, 890, 620],
-      "timestamp": "2026-02-10T15:23:41Z"
-    }
-  ]
-}
-```
-
-**YOLO** (training format):
-```
-# classes.txt
-text
-music
-staves
-
-# image_name.txt (normalized coordinates)
-1 0.523000 0.445000 0.120000 0.088889
-```
-
-### Class Definitions
-
-| Class | ID | Color | Description |
-|-------|----|----|-------------|
-| **Text** | 1 | Muted blue | Text with or without music; rubrics and initials included |
-| **Music** | 2 | Olive green | Complete staff systems including neumes |
-| **Staves** | 3 | Bronze/gold | Staff lines (may overlap with music) |
-
-**Overlapping boxes are intentional**: YOLO handles this well, and we use spatial overlap post-processing to assign neumes to specific staves for pitch inference.
-
----
-
-## Part 2: YOLO OMR Pipeline
-
-### Architecture Selection
-
-We are currently experimenting with using **[DocLayout-YOLO](https://github.com/opendatalab/DocLayout-YOLO)** as our base model because:
-
-1. **Document-specific optimizations** - Designed for complex layouts, small text, varied scales
-2. **GL-CRM module** - Global-to-Local Controllable Receptive fields handle neumes → initials range
-3. **Synthetic data pipeline** - DocSynth-300K approach adaptable to parchment degradation
-4. **YOLO11 foundation** - C2PSA attention for fine-grained symbol distinction
-
-**Alternative architectures considered:**
-- YOLO26 (STAL module for small targets) - may experiment if neume detection fails
-- Segmentation models (U-Net++, Mask R-CNN) - deferred; boxes faster to annotate
-
-### Training Strategy
-
-**Phase 1: Layout Detection** (*current focus*)
-- Train on text/music/staves classes
-- Goal: Robust region detection despite degradation
-- Success metric: mAP@0.5 > 0.85 on held-out manuscripts
-
-**Phase 2: Symbol Classification** (future)
-- Expand to neume-level classes if Phase 1 succeeds
-- Challenge: 30+ neume types, severe class imbalance
-- May require weighted loss, augmentation, or hierarchical classification
-
-### Dataset Requirements
-
-**Minimum viable:**
-- 50-100 annotated pages for initial experiments
-- Manuscript-aware splits (entire manuscripts stay in one split)
-- Balanced representation of degradation types
-
-**Full dataset:**
-- 200-500 pages for production model
-- Multiple scribes, time periods, repositories
-- Synthetic augmentation of rarer neume types
-
-### Data Splits
-
-**Critical: Manuscript-aware splitting**
-```python
-# scripts/split_dataset.py
-# DON'T: Random split (data leakage!)
-# DO: Split by manuscript ID
-manuscripts = group_by_manuscript(annotations)
-train_mss, val_mss, test_mss = split_manuscripts(0.7, 0.15, 0.15)
-```
-
-Why? Pages from the same manuscript have correlated characteristics (scribe, ink, parchment). Random splitting inflates validation metrics.
-
----
-
-## Installation & Setup
-
-### Prerequisites
-
-- **For annotation only**: Modern web browser (Chrome, Firefox, Safari)
-- **For YOLO training**: Python 3.8+, CUDA-capable GPU (recommended)
-
-### YOLO Environment Setup
-
-```bash
-# Clone repository
-git clone https://github.com/YOUR_USERNAME/mothra.git
-cd mothra
-
-# Create virtual environment
-python3 -m venv venv
-source venv/bin/activate  # or `venv\Scripts\activate` on Windows
-
-# Install dependencies
-pip install --break-system-packages -r requirements.txt
-
-# Clone DocLayout-YOLO
-cd experiments
-git clone https://github.com/opendatalab/DocLayout-YOLO.git
-cd DocLayout-YOLO
-pip install --break-system-packages -r requirements.txt
-```
-
-### Training Your First Model
-**_subject to change_**
-```bash
-# Organize data
-python scripts/convert_to_yolo.py --input data/annotations/ --output data/yolo/
-python scripts/split_dataset.py --input data/yolo/ --output data/splits/
-
-# Configure training
-# Edit experiments/configs/base_config.yaml with your paths
-
-# Train
-cd experiments/DocLayout-YOLO
-python train.py --config ../configs/base_config.yaml
-
-# Evaluate
-python val.py --weights runs/train/exp/weights/best.pt
-```
+`configs/`, `data/`, and the root-level training/inference scripts are the original
+YOLO layout-detection experiment track that predates `landing-page/` — still around and
+occasionally used, but less active than the web app.
 
 ---
 
 ## Comparison to Rodan
 
 | Feature | Rodan | Mothra |
-|---------|-------|--------|
-| **Approach** | Multi-stage pipeline | End-to-end detection |
-| **Layout Analysis** | Pixel.js, Gamera | YOLO object detection |
-| **Training Data** | Pixel-level masks | Bounding boxes |
-| **Annotation Time** | High (pixel painting) | Low (box drawing) |
-| **Degradation Handling** | Rule-based preprocessing | Learned robustness |
-| **Staff Detection** | Hough transform | Attention mechanism |
-| **Neume Classification** | Interactive Classifier | Direct detection (future) |
-| **Human in Loop** | Multiple stages | Annotation phase only |
-| **Inference Speed** | Slow (multi-stage) | Fast (single pass) |
-| **Deployment** | Complex (Docker stack) | Simple (model file) |
+|---|---|---|
+| **Approach** | Multi-stage pipeline | End-to-end object detection |
+| **Layout analysis** | Pixel.js, Gamera | YOLO |
+| **Training data** | Pixel-level masks | Bounding boxes |
+| **Staff detection** | Hough transform | Component filter + centerline fit + stave grouping (`staff-finding/`) |
+| **Neume classification / correction** | Interactive Classifier | Interactive Classifier (same tool, now standalone) |
+| **Pitch finding** | Built into the Rodan job graph | Standalone tool ([Standalone-Pitch-Finder](https://github.com/DDMAL/Standalone-Pitch-Finder)), not yet wired into the Mothra pipeline |
+| **Human in the loop** | Multiple pipeline stages | IC correction + Neon.js MEI correction |
+| **Deployment** | Docker stack | Kubernetes (see [`k8s/`](k8s/)) or Docker Compose |
 
-**Hypothesis**: Mothra trades Rodan's interpretability for speed and potentially better handling of degraded manuscripts through learned feature extraction.
-
----
-
-## Staff-Finding Evaluation
-
-Two scripts in `staff-finding/scripts/` measure how well the pipeline's fitted centerlines match ground-truth staffline annotations. Ground truth is supplied as standard YOLO `.txt` files (one detection per line); predictions come from the `*_stafflines.json` output of `run_page.py`.
-
-A predicted fit and a GT staffline box are considered a **match** when the fit's mean page-absolute y-center falls within `0.5 × scale_unit` pixels of the GT box's y-center. Matching is 1-to-1, resolved greedily by ascending distance.
-
-### Metrics reported
-
-| Metric | What it measures |
-|---|---|
-| `precision` | Fraction of predicted fits that matched a GT line |
-| `recall` | Fraction of GT lines that were matched |
-| `f1` | Harmonic mean of precision and recall |
-| `split_ratio` | `n_pred / n_gt` — values > 1 indicate over-detection |
-| `mean_y_mae_px` | Mean absolute y-error (pixels) for matched pairs, over their x-overlap |
-
-Each result row also records `page`, `variant` (e.g. `sauvola_no_bgr`), `gt_source` (annotator name or `corrected`), and a UTC `timestamp`.
-
-### `eval_page.py` — single page
-
-Evaluates one (GT, prediction) pair and optionally appends a row to a CSV.
-
-```bash
-python staff-finding/scripts/eval_page.py \
-  --gt   staff-finding/image-sets/gent/right/inference/corrected/GentAnt1475_0017_AC_rightcrop.txt \
-  --pred staff-finding/e2e_tests/.../GentAnt1475_0017_AC_rightcrop_stafflines.json \
-  --image staff-finding/image-sets/gent/right/GentAnt1475_0017_AC_rightcrop.jpg \
-  --gt-source corrected_kyrie \
-  --variant sauvola_no_bgr \
-  --output results.csv
-```
-
-### `eval_batch.py` — multiple pages and variants
-
-Reads a manifest CSV listing all (GT, prediction, image, metadata) triples and runs evaluation on each row, writing a combined results CSV. Pass `--summarize` to print a per-variant aggregate table (mean ± std across pages).
-
-```bash
-python staff-finding/scripts/eval_batch.py \
-  --manifest staff-finding/e2e_tests/eval_manifest.csv \
-  --output   staff-finding/e2e_tests/eval_results.csv \
-  --summarize
-```
-
-**Manifest format** (`eval_manifest.csv`):
-
-```csv
-page_name,image,gt_txt,gt_source,pred_json,variant
-GentAnt1475_0017_AC_rightcrop,staff-finding/image-sets/gent/right/GentAnt1475_0017_AC_rightcrop.jpg,path/to/gt.txt,corrected_kyrie,path/to/stafflines.json,sauvola_no_bgr
-```
-
-One row per (page × variant) combination. The `gt_source` column supports annotator tracking when multiple ground-truth sources are in use.
+**Hypothesis:** Mothra trades some of Rodan's interpretability for speed and,
+hopefully, better handling of degraded manuscripts through learned feature extraction.
 
 ---
 
-## Evaluation Metrics
+## Status & known gaps
 
-### Layout Detection (Phase 1)
-
-- **mAP@0.5**: Primary metric (COCO standard)
-- **Per-class AP**: Ensure balanced performance across text/music/staves
-- **Degradation robustness**: Test on manuscripts excluded from training with varying damage levels
-- **Cross-repository generalization**: Train on one archive, test on another
-
-### Symbol Classification (Phase 2, future)
-
-- **Top-1 accuracy**: For neume type classification  
-- **Confusion matrix**: Identify systematic errors
-- **Manuscript-level MEI accuracy**: End-to-end OMR quality
-
-### Qualitative Assessment
-
-- **Visual inspection**: Do boxes align with human perception?
-- **Failure mode analysis**: Where does it break? (extreme damage, rare neumes, unusual layouts)
-- **Comparison to Rodan**: Side-by-side on same manuscripts
+- **No end-to-end pitch-to-MEI in this repo yet** — staffline detection produces the
+  grid pitches would be read against, but pitch assignment itself lives in the separate
+  [Standalone-Pitch-Finder](https://github.com/DDMAL/Standalone-Pitch-Finder) and isn't
+  integrated into the `landing-page/` pipeline.
+- **Staffline detection** has a few features implemented but intentionally not yet
+  enabled by default (ink separation, gap interpolation, fallback re-detection) — see
+  [`staff-finding/dox/STATUS.md`](staff-finding/dox/STATUS.md).
+- **Mothra Print** currently covers one printed source (the Liber Usualis); a second
+  candidate manuscript is under consideration but not yet started.
+- See [`CLAUDE.md`](CLAUDE.md)'s "Things that don't exist yet" section for gaps specific
+  to the web app (job cleanup, health checks, IIIF import).
 
 ---
 
-## Known Limitations & Future Work
+## Contributing / where to look next
 
-### Current Limitations
-
-1. **No end-to-end OMR yet** - Layout detection only, no pitch inference
-2. **Small initial dataset** - 50-100 pages insufficient for production
-3. **No temporal modeling** - Doesn't exploit sequential structure of music
-4. **Overlapping boxes** - Require post-processing for pitch assignment
-
-### Future Directions
-
-1. **Expand to symbol-level** - 30+ neume classes
-2. **Pitch inference pipeline** - Combine with staff line detection for vertical position
-3. **Sequence modeling** - Transformer or LSTM for musical context
-4. **Synthetic data** - DocSynth-style generation for rare neumes
-5. **Multi-modal** - Combine visual detection with music theory constraints
-6. **Active learning** - Prioritize uncertain predictions for annotation
-
----
-
-## Contributing
-
-This is a research project, but contributions welcome:
-
-- **Annotations**: Help annotate manuscripts (use GitHub Pages tool)
-- **Code**: Bug fixes, optimizations, experiments
-- **Documentation**: Improve guides, add examples
-- **Data**: Share medieval manuscript datasets (with appropriate permissions)
-
-### Annotation Guidelines
-
-See `docs/ANNOTATION_GUIDE.md` for detailed instructions on:
-- What counts as a text region vs. music system
-- Handling decorated initials
-- Edge cases (marginal annotations, fragmentary staves)
-- Quality control procedures
+- Working on the web app? Start with [`CLAUDE.md`](CLAUDE.md).
+- Working on staffline detection? Start with
+  [`staff-finding/dox/STATUS.md`](staff-finding/dox/STATUS.md) and
+  [`staff-finding/README.md`](staff-finding/README.md).
+- Curious about the project's original scope and open questions?
+  [`documentation_allons-y/PLAN.md`](documentation_allons-y/PLAN.md) is the original
+  brief; [`documentation_allons-y/STAFFLINE_INTEGRATION_FOLLOWUPS.md`](documentation_allons-y/STAFFLINE_INTEGRATION_FOLLOWUPS.md)
+  tracks live follow-ups from wiring staffline detection into the pipeline.
+- Interactive Classifier or pitch finding? Those are developed in their own repos —
+  see the ecosystem table above.
 
 ---
 
 **Key papers this draws on:**
 
 - DocLayout-YOLO: [arXiv:2410.12628](https://arxiv.org/abs/2410.12628)
-- YOLO for Medieval Music: "Optical Medieval Music Recognition Using Background Knowledge" (MDPI 2022)
+- "Optical Medieval Music Recognition Using Background Knowledge" (MDPI, 2022)
 - Rodan: [ddmal.github.io/Rodan](https://ddmal.github.io/Rodan)
-

--- a/landing-page/scripts/auth_api.py
+++ b/landing-page/scripts/auth_api.py
@@ -330,6 +330,23 @@ def _migrate_db():
         cur.close()
         release_db_conn(con)
 
+    # Records which of tasks_encode.py's 3-tier stave-source fallback actually
+    # produced this MEI's zones ("staffline_detection" / "yolo_annotation" /
+    # "glyph_estimate" / "glyph_estimate_unresolved_lines" /
+    # "glyph_estimate_synthetic_lines" / "placeholder_no_glyphs") -- see
+    # CLAUDE.md's "Staffline detection" section. NULL for MEI files encoded
+    # before this column existed.
+    con = get_db_conn()
+    cur = con.cursor()
+    try:
+        cur.execute("ALTER TABLE mei_files ADD COLUMN stave_source TEXT")
+        con.commit()
+    except psycopg2.errors.DuplicateColumn:
+        con.rollback()
+    finally:
+        cur.close()
+        release_db_conn(con)
+
     con = get_db_conn()
     cur = con.cursor()
     try:

--- a/landing-page/scripts/encode_api.py
+++ b/landing-page/scripts/encode_api.py
@@ -34,6 +34,7 @@ async def encode_upload(
     image_name: Optional[str] = Form(None),
     clef_shape: Optional[str] = Form(None),
     clef_line: Optional[int] = Form(None),
+    allow_synthetic_lines: bool = Form(False),
 ):
     xml_bytes = await xml_file.read()
     xml_filename = xml_file.filename or "uplaoded.xml"
@@ -57,6 +58,7 @@ async def encode_upload(
         "image_name": image_name,
         "clef_shape": clef_shape,
         "clef_line": clef_line,
+        "allow_synthetic_lines": allow_synthetic_lines,
     }
     create_job(job_id, "encode_upload", project_id, params=kwargs)  # dedupe_seconds=0 (default): always creates
     run_encode_upload_task.apply_async(kwargs={"job_id": job_id, **kwargs}, task_id=job_id)
@@ -98,6 +100,7 @@ async def encode_batch(
     project_id: Optional[int] = Form(None),
     clef_shape: Optional[str] = Form(None),
     clef_line: Optional[int] = Form(None),
+    allow_synthetic_lines: bool = Form(False),
 ):
     if len(xml_files) != len(image_files):
         return JSONResponse(status_code=400, content={
@@ -131,6 +134,7 @@ async def encode_batch(
         "project_id": project_id,
         "clef_shape": clef_shape,
         "clef_line": clef_line,
+        "allow_synthetic_lines": allow_synthetic_lines,
     }
     create_job(job_id, "encode_batch", project_id, params=kwargs)  # dedupe_seconds=0 (default): always creates
     run_encode_batch_task.apply_async(kwargs={"job_id": job_id, **kwargs}, task_id=job_id)

--- a/landing-page/scripts/encode_to_mei.py
+++ b/landing-page/scripts/encode_to_mei.py
@@ -164,7 +164,8 @@ def image_dimensions(header: bytes) -> Optional[tuple]:
     return None
 
 def assign_glyphs_to_staves(
-        glyphs: list[Glyph], staves: list[StaveBbox], page_w: int, page_h: int
+        glyphs: list[Glyph], staves: list[StaveBbox], page_w: int, page_h: int,
+        allow_synthetic_lines: bool = False,
 ) -> tuple[dict[int, list[Glyph]], list[StaveBbox]]:
     """Assign each glyph to a stave.
 
@@ -179,6 +180,13 @@ def assign_glyphs_to_staves(
     detected stave is assigned to it as before; a row that overlaps nothing
     is a system the detector missed, and gets a synthesized stave of its own.
 
+    allow_synthetic_lines is forwarded to that recovery clustering
+    (_cluster_glyphs_into_staves) so a recovered stave's line_ys follows the
+    same opt-in-fabrication rule as tier-3's own estimate_staves_from_glyphs
+    fallback -- without this, a page could end up with tier-3 staves carrying
+    synthetic pitch geometry while recovered staves silently didn't, even
+    though the caller asked for synthetic lines everywhere.
+
     Returns (glyphs_by_stave, staves) — `staves` may be LONGER than the input
     (synthesized entries appended at the end). Callers must build zones/
     <sb>/<clef> from the RETURNED staves list, not the one passed in.
@@ -189,7 +197,9 @@ def assign_glyphs_to_staves(
         return result, staves
 
     result = {i: [] for i in range(len(staves))}
-    row_groups = _cluster_glyphs_into_staves(glyphs, page_w, page_h, id_prefix="row")
+    row_groups = _cluster_glyphs_into_staves(
+        glyphs, page_w, page_h, id_prefix="row", allow_synthetic_lines=allow_synthetic_lines,
+    )
 
     for row_stave, members in row_groups:
         best_idx, best_overlap = None, 0
@@ -970,8 +980,17 @@ def trace_stave_zone_parity(staves: list[StaveBbox], mei_bytes: bytes) -> list[s
         if zone is None:
             mismatches.append(f"stave {stave.id}: no matching zone written")
             continue
-        written = (int(zone.get("ulx")), int(zone.get("uly")), int(zone.get("lrx")), int(zone.get("lry")))
-        expected = (stave.ulx, stave.uly, stave.lrx, stave.lry)
+        # float(), not int(): build_mei() writes str(stave.ulx) etc. verbatim,
+        # and StaveBbox's own type hints (int) aren't enforced at runtime --
+        # a fractional coordinate reaching here would otherwise raise
+        # ValueError and abort the whole encode job over what's meant to be a
+        # tracing-only check.
+        try:
+            written = tuple(float(zone.get(k)) for k in ("ulx", "uly", "lrx", "lry"))
+        except (TypeError, ValueError):
+            mismatches.append(f"stave {stave.id}: zone has unparsable coordinates")
+            continue
+        expected = tuple(float(v) for v in (stave.ulx, stave.uly, stave.lrx, stave.lry))
         if written != expected:
             mismatches.append(f"stave {stave.id}: expected {expected}, zone has {written}")
 

--- a/landing-page/scripts/encode_to_mei.py
+++ b/landing-page/scripts/encode_to_mei.py
@@ -293,12 +293,23 @@ def parse_yolo_stave_hints(yolo_txt: str, img_w: int, img_h: int) -> list[StaveB
     return _staves_from_staff_lines(lines, img_w, img_h)
 
 def _cluster_glyphs_into_staves(
-        glyphs: list[Glyph], page_w: int, page_h: int, id_prefix: str = "auto"
+        glyphs: list[Glyph], page_w: int, page_h: int, id_prefix: str = "auto",
+        allow_synthetic_lines: bool = False,
 ) -> list[tuple[StaveBbox, list[Glyph]]]:
     """Cluster glyphs into stave-sized row groups by Y-center gap, pairing each
     synthesized StaveBbox with the exact glyphs that produced it. Shared by
     estimate_staves_from_glyphs's no-stave-data fallback and by
-    assign_glyphs_to_staves's missed-stave recovery (see there)."""
+    assign_glyphs_to_staves's missed-stave recovery (see there).
+
+    The resulting StaveBbox's bounding box is always real (derived from the
+    glyph cluster itself), but its internal `line_ys` -- used only for pitch
+    computation, via _nc_pitch -- has no real measured staff-line data behind
+    it in this fallback. allow_synthetic_lines controls whether to fabricate
+    plausible-looking, perfectly evenly-spaced line_ys anyway (the old,
+    always-on behavior) or leave line_ys empty so _nc_pitch's own <2-entry
+    guard degrades to an explicit unresolved default ("a", "3") instead of a
+    confident-looking but invented pitch. Default False -- see
+    estimate_staves_from_glyphs's own docstring for why."""
     if not glyphs:
         return []
     neume_like = [g for g in glyphs if g.nrows > 0 and g.ncols / g.nrows < 8]
@@ -330,28 +341,42 @@ def _cluster_glyphs_into_staves(
             uly=max(0, min(g.uly for g in row) - pad),
             lrx=min(page_w, max(g.lrx for g in row) + pad),
             lry=min(page_h, max(g.lry for g in row) + pad),
-            line_ys=[est_uly + h * j / 3 for j in range(4)],
+            line_ys=[est_uly + h * j / 3 for j in range(4)] if allow_synthetic_lines else [],
         )
         groups.append((stave, row))
     return groups
 
 
 def estimate_staves_from_glyphs(
-    glyphs: list[Glyph], page_w: int, page_h: int
-) -> list[StaveBbox]:
-    """Estimate stave bounding boxes from GameraXML glyphs.
+    glyphs: list[Glyph], page_w: int, page_h: int, allow_synthetic_lines: bool = False,
+) -> tuple[list[StaveBbox], str]:
+    """Estimate stave bounding boxes from GameraXML glyphs. This is tier 3 of
+    tasks_encode.py's 3-tier stave-source fallback (staffline_detection ->
+    yolo_annotation -> this) -- the caller uses the returned tag as that
+    tier's `stave_source` value.
 
     Primary strategy: cluster the detected staff lines (wide, flat glyphs with
     aspect ratio ≥ 8 spanning >20% of page width).  These are highly reliable
     stave anchors and are unaffected by text characters that fill inter-stave
     gaps and cause the neume-Y-clustering approach to collapse all staves into
-    one.
+    one. Tagged "glyph_estimate" -- real, page-specific geometry.
 
     Fallback: if too few staff lines are available, cluster neume-like glyphs
-    by Y-center gap (original approach with tighter outlier filtering).
+    by Y-center gap (original approach with tighter outlier filtering). The
+    stave bounding box here is still real (from the glyph cluster), but its
+    internal line positions are not measured -- see _cluster_glyphs_into_staves's
+    own docstring for allow_synthetic_lines. Tagged "glyph_estimate_synthetic_lines"
+    when allow_synthetic_lines fabricated plausible-looking line_ys, or
+    "glyph_estimate_unresolved_lines" (default) when it didn't -- either way,
+    distinct from "glyph_estimate" so this weaker case is never conflated with
+    strategy 1's real per-page staff-line geometry.
+
+    Zero-glyph case: no real geometry exists at all. Returns one hardcoded
+    full-page StaveBbox tagged "placeholder_no_glyphs" -- callers should treat
+    this as a warning-worthy result, not silent success.
     """
     if not glyphs:
-        return [StaveBbox(id="synth-0", ulx=0, uly=0, lrx=page_w, lry=page_h)]
+        return [StaveBbox(id="synth-0", ulx=0, uly=0, lrx=page_w, lry=page_h)], "placeholder_no_glyphs"
 
     # ── Strategy 1: use staff line glyphs ──────────────────────────────────
     # Staff lines span most of the page width and have ncols >> nrows.
@@ -364,10 +389,16 @@ def estimate_staves_from_glyphs(
     if len(staff_lines) >= 4:
         staves = _staves_from_staff_lines(staff_lines, page_w, page_h)
         if staves:
-            return staves
+            return staves, "glyph_estimate"
 
     # ── Strategy 2: neume Y-gap clustering (fallback) ──────────────────────
-    return [stave for stave, _ in _cluster_glyphs_into_staves(glyphs, page_w, page_h)]
+    staves = [
+        stave for stave, _ in _cluster_glyphs_into_staves(
+            glyphs, page_w, page_h, allow_synthetic_lines=allow_synthetic_lines,
+        )
+    ]
+    detail = "glyph_estimate_synthetic_lines" if allow_synthetic_lines else "glyph_estimate_unresolved_lines"
+    return staves, detail
 
 
 def _staves_from_staff_lines(

--- a/landing-page/scripts/encode_to_mei.py
+++ b/landing-page/scripts/encode_to_mei.py
@@ -931,6 +931,55 @@ def validate_mei(xml_bytes: bytes) -> list[str]:
 
     return warnings
 
+
+def trace_stave_zone_parity(staves: list[StaveBbox], mei_bytes: bytes) -> list[str]:
+    """Parse a just-built MEI's actual <zone type="staff"> elements back out
+    and confirm they match the StaveBbox list build_mei() was handed for it
+    -- same count, same coordinates. build_mei() writes each zone's
+    ulx/uly/lrx/lry straight from the corresponding StaveBbox (zone id
+    convention: `sz-{stave.id}`, see build_mei() itself), so any mismatch
+    here would mean something between stave resolution and encoding silently
+    altered the geometry Neon ends up displaying -- not something that
+    should ever legitimately happen, hence a "[warn]"-prefixed message
+    rather than a quiet one when it does.
+
+    Returns a list of "[trace] ..." message strings for the caller to
+    publish however it likes (a job-log event, a print, a test assertion --
+    kept DB/Celery-independent on purpose so it's testable like the rest of
+    this module, unlike tasks_encode.py which connects to Postgres at
+    import time)."""
+    try:
+        root = ET.fromstring(mei_bytes)
+        zones = {
+            z.get(XML_ID): z
+            for z in root.iter(_tag("zone"))
+            if z.get("type") == "staff"
+        }
+    except ET.ParseError as e:
+        return [f"[trace] [warn] could not parse MEI back out to verify zones: {e}"]
+
+    if len(zones) != len(staves):
+        return [
+            f"[trace] [warn] stave/zone count mismatch: {len(staves)} StaveBbox(es) handed to"
+            f" build_mei(), {len(zones)} type=\"staff\" zone(s) actually written"
+        ]
+
+    mismatches = []
+    for stave in staves:
+        zone = zones.get(f"sz-{stave.id}")
+        if zone is None:
+            mismatches.append(f"stave {stave.id}: no matching zone written")
+            continue
+        written = (int(zone.get("ulx")), int(zone.get("uly")), int(zone.get("lrx")), int(zone.get("lry")))
+        expected = (stave.ulx, stave.uly, stave.lrx, stave.lry)
+        if written != expected:
+            mismatches.append(f"stave {stave.id}: expected {expected}, zone has {written}")
+
+    if mismatches:
+        return [f"[trace] [warn] {len(mismatches)} stave zone(s) diverged from input: " + "; ".join(mismatches)]
+    return [f"[trace] {len(staves)} stave zone(s) verified identical to build_mei()'s input"]
+
+
 def build_neon_manifest(mei_bytes: bytes, image_ref: str, stem: str) -> dict:
     mei_b64 = base64.b64encode(mei_bytes).decode()
     return {

--- a/landing-page/scripts/inference_api.py
+++ b/landing-page/scripts/inference_api.py
@@ -1,12 +1,16 @@
+import io
 from typing import Optional, Literal
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
+import numpy as np
+from PIL import Image
 import uuid as _uuid
 
 from auth_api import get_current_user, require_project_owner, db_cursor
 from config import SKIP_YOLO
 from job_store import create_job
 from tasks_predict import run_predict_task
+import staffline_stage
 
 router = APIRouter()
 
@@ -117,4 +121,128 @@ async def get_staffline_detection(
     return {
         "jsomrJson": row[0], "imageName": row[1], "scaleUnit": row[2],
         "staveCount": row[3], "modeLinesPerStave": row[4], "status": row[5],
+    }
+
+
+def _load_image_and_yolo_for_detection(cur, project_id: int, detection_id: str, user_id: int):
+    """Looks up a staffline_detections row's image_id/image_name, then loads
+    that image's bytes and its CURRENT annotation's yolo_txt -- deliberately
+    the latest annotations row by image_id, not the detection's own
+    annotation_id, since a later re-annotate replaces that row entirely via
+    write_annotation()'s delete+insert (see yolo_inference.write_annotation),
+    which would leave an older detection's annotation_id pointing at
+    nothing. Raises HTTPException(404) if the detection, image, or a
+    current annotation isn't found."""
+    cur.execute(
+        "SELECT s.image_id, s.image_name"
+        " FROM staffline_detections s"
+        " JOIN projects p ON p.id = s.project_id"
+        " WHERE s.id = %s AND s.project_id = %s AND p.user_id = %s",
+        (detection_id, project_id, user_id),
+    )
+    row = cur.fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="staffline detection not found")
+    image_id, image_name = row
+
+    cur.execute(
+        "SELECT data FROM project_images WHERE id=%s AND project_id=%s",
+        (image_id, project_id),
+    )
+    img_row = cur.fetchone()
+    if not img_row:
+        raise HTTPException(status_code=404, detail=f"image {image_id} not found")
+    image_arr = np.array(Image.open(io.BytesIO(bytes(img_row[0]))).convert("RGB"))
+
+    cur.execute(
+        "SELECT id, yolo_txt FROM annotations WHERE project_id=%s AND image_id=%s"
+        " ORDER BY created_at DESC LIMIT 1",
+        (project_id, image_id),
+    )
+    ann_row = cur.fetchone()
+    if not ann_row:
+        raise HTTPException(status_code=404, detail=f"no current annotation for image {image_id}")
+    annotation_id, yolo_txt = ann_row
+
+    return image_id, image_name, annotation_id, image_arr, yolo_txt
+
+
+@router.post("/projects/{project_id}/stafflines/{detection_id}/interpolate-preview")
+async def preview_staffline_interpolation(
+    project_id: int,
+    detection_id: str,
+    user=Depends(get_current_user),
+):
+    """Computes what turning on interpolate_missing would produce for this
+    image -- without persisting anything. Lets the frontend show the
+    would-be result (dashed interpolated lines, same as any other
+    source="interpolated" JSOMR record) before the user chooses to accept
+    it via interpolate-confirm below. See staffline_stage.preview_interpolation's
+    own docstring for why this is opt-in review-first rather than always-on:
+    staff-finding/dox/STATUS.md flags interpolate_missing as "not yet
+    validated across the corpus"."""
+    with db_cursor() as (con, cur):
+        _image_id, image_name, _ann_id, image_arr, yolo_txt = _load_image_and_yolo_for_detection(
+            cur, project_id, detection_id, user["id"],
+        )
+    records = staffline_stage.preview_interpolation(image_name, image_arr, yolo_txt)
+    if records is None:
+        raise HTTPException(status_code=422, detail="nothing to interpolate for this image")
+    return {"jsomrJson": records}
+
+
+@router.post("/projects/{project_id}/stafflines/{detection_id}/interpolate-confirm")
+async def confirm_staffline_interpolation(
+    project_id: int,
+    detection_id: str,
+    user=Depends(get_current_user),
+):
+    """Re-runs real staffline detection with interpolate_missing=True and
+    persists it as a NEW staffline_detections row -- matches that table's
+    existing accumulate-forever design (see
+    documentation_allons-y/STAFFLINE_INTEGRATION_FOLLOWUPS.md's retention
+    note, which already anticipated exactly this before/after-interpolation
+    comparison use case), so the pre-interpolation detection this was
+    previewed from is still there too, not overwritten.
+
+    Deliberately re-runs rather than persisting whatever interpolate-preview
+    returned verbatim: detection is deterministic given the same inputs, so
+    this avoids trusting/re-validating a client-supplied JSOMR payload for
+    something that writes to the DB.
+
+    Uses a fresh, never-registered job id purely so run_staffline_detection's
+    existing check_cancelled(job_id) calls have something to look up --
+    job_store.get_job_status() returns None for an unknown id, which
+    check_cancelled treats as "not cancelled", so this never actually
+    behaves like a trackable/cancellable job (there isn't one)."""
+    with db_cursor() as (con, cur):
+        image_id, image_name, annotation_id, image_arr, yolo_txt = _load_image_and_yolo_for_detection(
+            cur, project_id, detection_id, user["id"],
+        )
+        throwaway_job_id = _uuid.uuid4().hex
+        error_message = None
+        for ev in staffline_stage.run_staffline_detection(
+            throwaway_job_id, cur, con, project_id, image_id, image_name, annotation_id,
+            image_arr, yolo_txt, interpolate_missing=True,
+        ):
+            if ev.get("type") == "error":
+                error_message = ev.get("message", "staffline detection failed")
+        if error_message:
+            raise HTTPException(status_code=500, detail=error_message)
+
+        cur.execute(
+            "SELECT id, image_id, image_name, stave_count, mode_lines_per_stave, status"
+            " FROM staffline_detections WHERE project_id=%s AND image_id=%s"
+            " ORDER BY created_at DESC, id DESC LIMIT 1",
+            (project_id, image_id),
+        )
+        row = cur.fetchone()
+    if not row:
+        raise HTTPException(status_code=500, detail="interpolation did not produce a new detection")
+    did, img_id, img_name, stave_count, mode_lines_per_stave, status = row
+    return {
+        "id": did, "imageName": img_name,
+        "imageSrc": f"/api/images/{img_id}" if img_id else None,
+        "staveCount": stave_count, "modeLinesPerStave": mode_lines_per_stave,
+        "status": status,
     }

--- a/landing-page/scripts/inference_api.py
+++ b/landing-page/scripts/inference_api.py
@@ -168,7 +168,7 @@ def _load_image_and_yolo_for_detection(cur, project_id: int, detection_id: str, 
 
 
 @router.post("/projects/{project_id}/stafflines/{detection_id}/interpolate-preview")
-async def preview_staffline_interpolation(
+def preview_staffline_interpolation(
     project_id: int,
     detection_id: str,
     user=Depends(get_current_user),
@@ -180,7 +180,13 @@ async def preview_staffline_interpolation(
     it via interpolate-confirm below. See staffline_stage.preview_interpolation's
     own docstring for why this is opt-in review-first rather than always-on:
     staff-finding/dox/STATUS.md flags interpolate_missing as "not yet
-    validated across the corpus"."""
+    validated across the corpus".
+
+    Plain `def`, not `async def`: this does blocking, CPU-bound work
+    (image decode + component filtering/centerline fitting) directly, so
+    FastAPI needs to run it in its threadpool rather than on the event
+    loop, where it would stall every other concurrent request for its
+    duration."""
     with db_cursor() as (con, cur):
         _image_id, image_name, _ann_id, image_arr, yolo_txt = _load_image_and_yolo_for_detection(
             cur, project_id, detection_id, user["id"],
@@ -192,7 +198,7 @@ async def preview_staffline_interpolation(
 
 
 @router.post("/projects/{project_id}/stafflines/{detection_id}/interpolate-confirm")
-async def confirm_staffline_interpolation(
+def confirm_staffline_interpolation(
     project_id: int,
     detection_id: str,
     user=Depends(get_current_user),
@@ -214,12 +220,18 @@ async def confirm_staffline_interpolation(
     existing check_cancelled(job_id) calls have something to look up --
     job_store.get_job_status() returns None for an unknown id, which
     check_cancelled treats as "not cancelled", so this never actually
-    behaves like a trackable/cancellable job (there isn't one)."""
+    behaves like a trackable/cancellable job (there isn't one).
+
+    Plain `def`, not `async def` -- same reason as interpolate-preview
+    above, and this one additionally holds a pooled DB connection open for
+    the whole detection run, so it especially shouldn't sit on the event
+    loop."""
     with db_cursor() as (con, cur):
         image_id, image_name, annotation_id, image_arr, yolo_txt = _load_image_and_yolo_for_detection(
             cur, project_id, detection_id, user["id"],
         )
         throwaway_job_id = _uuid.uuid4().hex
+        new_detection_id = None
         error_message = None
         for ev in staffline_stage.run_staffline_detection(
             throwaway_job_id, cur, con, project_id, image_id, image_name, annotation_id,
@@ -227,14 +239,22 @@ async def confirm_staffline_interpolation(
         ):
             if ev.get("type") == "error":
                 error_message = ev.get("message", "staffline detection failed")
+            elif ev.get("type") == "detection_id":
+                new_detection_id = ev.get("id")
         if error_message:
             raise HTTPException(status_code=500, detail=error_message)
+        if not new_detection_id:
+            raise HTTPException(status_code=500, detail="interpolation did not produce a new detection")
 
+        # Look up by the id run_staffline_detection itself just generated and
+        # inserted, not "the latest row for this image" -- created_at uses
+        # DEFAULT NOW() (transaction-start time, so same-transaction inserts
+        # can share an identical value) and id is a random uuid4, so neither
+        # is a reliable insertion-order tiebreak on its own.
         cur.execute(
             "SELECT id, image_id, image_name, stave_count, mode_lines_per_stave, status"
-            " FROM staffline_detections WHERE project_id=%s AND image_id=%s"
-            " ORDER BY created_at DESC, id DESC LIMIT 1",
-            (project_id, image_id),
+            " FROM staffline_detections WHERE id=%s AND project_id=%s",
+            (new_detection_id, project_id),
         )
         row = cur.fetchone()
     if not row:

--- a/landing-page/scripts/inference_api.py
+++ b/landing-page/scripts/inference_api.py
@@ -216,37 +216,32 @@ def confirm_staffline_interpolation(
     this avoids trusting/re-validating a client-supplied JSOMR payload for
     something that writes to the DB.
 
-    Uses a fresh, never-registered job id purely so run_staffline_detection's
-    existing check_cancelled(job_id) calls have something to look up --
-    job_store.get_job_status() returns None for an unknown id, which
-    check_cancelled treats as "not cancelled", so this never actually
-    behaves like a trackable/cancellable job (there isn't one).
-
     Plain `def`, not `async def` -- same reason as interpolate-preview
-    above, and this one additionally holds a pooled DB connection open for
-    the whole detection run, so it especially shouldn't sit on the event
-    loop."""
+    above. Also, unlike run_staffline_detection() (which bundles compute and
+    persist under one connection its own callers already hold for an entire
+    per-image loop regardless), this route deliberately does NOT hold a
+    database connection during the CPU-bound detection step: component
+    filtering/centerline fitting on a real manuscript page can take real
+    time, and several concurrent confirmations each pinning a pooled
+    connection for that whole duration could exhaust the pool and block
+    unrelated requests. So: load inputs (connection released before
+    returning from the `with`), compute via compute_staffline_interpolation()
+    with no connection held at all, then reacquire one just for the cheap
+    persist_staffline_detection() write."""
     with db_cursor() as (con, cur):
         image_id, image_name, annotation_id, image_arr, yolo_txt = _load_image_and_yolo_for_detection(
             cur, project_id, detection_id, user["id"],
         )
-        throwaway_job_id = _uuid.uuid4().hex
-        new_detection_id = None
-        error_message = None
-        for ev in staffline_stage.run_staffline_detection(
-            throwaway_job_id, cur, con, project_id, image_id, image_name, annotation_id,
-            image_arr, yolo_txt, interpolate_missing=True,
-        ):
-            if ev.get("type") == "error":
-                error_message = ev.get("message", "staffline detection failed")
-            elif ev.get("type") == "detection_id":
-                new_detection_id = ev.get("id")
-        if error_message:
-            raise HTTPException(status_code=500, detail=error_message)
-        if not new_detection_id:
-            raise HTTPException(status_code=500, detail="interpolation did not produce a new detection")
 
-        # Look up by the id run_staffline_detection itself just generated and
+    computed = staffline_stage.compute_staffline_interpolation(image_name, image_arr, yolo_txt)
+    if computed is None:
+        raise HTTPException(status_code=422, detail="nothing to interpolate for this image")
+
+    with db_cursor() as (con, cur):
+        new_detection_id = staffline_stage.persist_staffline_detection(
+            cur, con, project_id, image_id, image_name, annotation_id, computed,
+        )
+        # Look up by the id persist_staffline_detection just generated and
         # inserted, not "the latest row for this image" -- created_at uses
         # DEFAULT NOW() (transaction-start time, so same-transaction inserts
         # can share an identical value) and id is a random uuid4, so neither

--- a/landing-page/scripts/mei_api.py
+++ b/landing-page/scripts/mei_api.py
@@ -21,6 +21,7 @@ class AddMeiBody(BaseModel):
     xmlContent: str
     imageName: Optional[str] = None
     logs: Optional[list[str]] = None
+    staveSource: Optional[str] = None
 
 @router.post("/projects/{project_id}/mei")
 def add_mei(project_id: int, body: AddMeiBody, user=Depends(get_current_user)):
@@ -28,8 +29,8 @@ def add_mei(project_id: int, body: AddMeiBody, user=Depends(get_current_user)):
         require_project_owner(cur, project_id, user["id"])
         mei_id = _uuid.uuid4().hex
         cur.execute(
-            "INSERT INTO mei_files (id, project_id, name, xml_content, image_name) VALUES (%s,%s,%s,%s,%s)",
-            (mei_id, project_id, body.name, body.xmlContent, body.imageName))
+            "INSERT INTO mei_files (id, project_id, name, xml_content, image_name, stave_source) VALUES (%s,%s,%s,%s,%s,%s)",
+            (mei_id, project_id, body.name, body.xmlContent, body.imageName, body.staveSource))
         if body.logs:
             content = "\n".join(body.logs)
             cur.execute(

--- a/landing-page/scripts/mei_api.py
+++ b/landing-page/scripts/mei_api.py
@@ -3,7 +3,7 @@ token-authed raw-content endpoints the embedded Neon editor iframe uses."""
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import Response
 from pydantic import BaseModel
-from typing import Optional
+from typing import Literal, Optional
 import base64
 import json
 import uuid as _uuid
@@ -15,13 +15,24 @@ from auth_api import (
 
 router = APIRouter()
 
+# Matches types.ts's StaveSource union and the tags tasks_encode.py's
+# 3-tier fallback actually produces (see auth_api.py's mei_files.stave_source
+# migration comment) -- a Literal here keeps this column's contents aligned
+# with what the frontend badge (MeiViewerModal.tsx) knows how to render,
+# instead of accepting any string a client sends.
+StaveSource = Literal[
+    "staffline_detection", "yolo_annotation", "glyph_estimate",
+    "glyph_estimate_unresolved_lines", "glyph_estimate_synthetic_lines",
+    "placeholder_no_glyphs",
+]
+
 
 class AddMeiBody(BaseModel):
     name: str
     xmlContent: str
     imageName: Optional[str] = None
     logs: Optional[list[str]] = None
-    staveSource: Optional[str] = None
+    staveSource: Optional[StaveSource] = None
 
 @router.post("/projects/{project_id}/mei")
 def add_mei(project_id: int, body: AddMeiBody, user=Depends(get_current_user)):

--- a/landing-page/scripts/projects_api.py
+++ b/landing-page/scripts/projects_api.py
@@ -82,8 +82,8 @@ def _project_row_to_dict(cur, row, username):
     images = [{"id": r[0], "name": r[1], "folio": r[2], "sourceId": r[3], "sourceName": r[4]} for r in cur.fetchall()]
     cur.execute("SELECT id, name, COALESCE(kind, 'yolo') FROM project_models WHERE project_id=%s", (pid,))
     models = [{"id": r[0], "name": r[1], "kind": r[2]} for r in cur.fetchall()]
-    cur.execute("SELECT id, name, xml_content, corrected, image_name FROM mei_files WHERE project_id=%s", (pid,))
-    mei = [{"id": r[0], "name": r[1], "xmlContent": r[2], "corrected": bool(r[3]), "imageName": r[4]}
+    cur.execute("SELECT id, name, xml_content, corrected, image_name, stave_source FROM mei_files WHERE project_id=%s", (pid,))
+    mei = [{"id": r[0], "name": r[1], "xmlContent": r[2], "corrected": bool(r[3]), "imageName": r[4], "staveSource": r[5]}
            for r in cur.fetchall()]
     cur.execute("SELECT id, image_id, image_name, model_label FROM annotations WHERE project_id=%s", (pid,))
     annotations = [_map_annotation_row(r[0], r[1], r[2], r[3]) for r in cur.fetchall()]
@@ -145,13 +145,14 @@ def list_projects(user=Depends(get_current_user)):
             models_by_pid.setdefault(pid, []).append({"id": mid, "name": mname, "kind": mkind})
 
         cur.execute(
-            "SELECT project_id, id, name, xml_content, corrected, image_name"
+            "SELECT project_id, id, name, xml_content, corrected, image_name, stave_source"
             " FROM mei_files WHERE project_id IN %s", (pids,)
         )
         mei_by_pid: dict = {}
-        for pid, fid, fname, xml, corr, iname in cur.fetchall():
+        for pid, fid, fname, xml, corr, iname, stave_source in cur.fetchall():
             mei_by_pid.setdefault(pid, []).append(
-                {"id": fid, "name": fname, "xmlContent": xml, "corrected": bool(corr), "imageName": iname}
+                {"id": fid, "name": fname, "xmlContent": xml, "corrected": bool(corr), "imageName": iname,
+                 "staveSource": stave_source}
             )
 
         cur.execute(

--- a/landing-page/scripts/staffline_stage.py
+++ b/landing-page/scripts/staffline_stage.py
@@ -269,6 +269,73 @@ def preview_interpolation(image_name: str, image_arr: np.ndarray, yolo_txt: str)
     return result["records"]
 
 
+def compute_staffline_interpolation(image_name: str, image_arr: np.ndarray, yolo_txt: str) -> Optional[dict]:
+    """Like preview_interpolation(), but returns everything
+    persist_staffline_detection() needs to write a full row -- not just the
+    JSOMR records -- so a caller can run this CPU-bound computation without
+    holding a database connection open, then reacquire one just for the
+    (cheap) persist step. This is what inference_api.py's interpolate-confirm
+    route uses instead of run_staffline_detection() directly, precisely to
+    avoid tying up a pooled connection for the duration of component
+    filtering/centerline fitting -- run_staffline_detection() itself is fine
+    holding one, since its callers (tasks_predict.py/tasks_text_batch.py)
+    already own that connection for the whole per-image loop regardless.
+
+    Returns None under the same conditions as preview_interpolation()."""
+    from yolo_io import parse_yolo_lines, filter_to_class
+
+    detections = filter_to_class(
+        parse_yolo_lines(yolo_txt.splitlines(), source=f"{image_name} annotation"),
+        STAFFLINE_CLASS_ID,
+    )
+    if not detections:
+        return None
+
+    h, w = image_arr.shape[:2]
+    scale_unit = _compute_page_scale_unit(detections, w, h)
+    result = _fit_and_group(image_name, image_arr, w, h, detections, scale_unit, interpolate_missing=True)
+    if result["degenerate"]:
+        return None
+
+    return {
+        "records": result["records"],
+        "stave_ids": result["stave_ids"],
+        "grouping_result": result["grouping_result"],
+        "scale_unit": scale_unit,
+        "settings": {
+            "interpolate_missing": True,
+            "binarization": "sauvola",
+            "bgr_enabled": False,  # ink-separation deferred this pass, see module docstring
+            "package_version": _package_version(),
+        },
+    }
+
+
+def persist_staffline_detection(cur, con, project_id: str, image_id: str, image_name: str,
+                                 annotation_id: str, computed: dict) -> str:
+    """INSERT-and-commit a succeeded detection result using an already-open
+    cursor/connection -- the shared write side for both
+    run_staffline_detection() (computes and persists on the same connection)
+    and inference_api.py's interpolate-confirm route (computes via
+    compute_staffline_interpolation() with no connection held, then calls
+    this against a freshly reacquired one). Returns the new row's id."""
+    new_id = _uuid.uuid4().hex
+    records = computed["records"]
+    cur.execute(
+        "INSERT INTO staffline_detections"
+        " (id, project_id, image_id, image_name, annotation_id, jsomr_json,"
+        "  scale_unit, stave_count, mode_lines_per_stave, settings_json, status)"
+        " VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,'succeeded')",
+        (
+            new_id, project_id, image_id, image_name, annotation_id,
+            json.dumps(records), computed["scale_unit"], len(computed["stave_ids"]),
+            computed["grouping_result"].mode_lines_per_stave, json.dumps(computed["settings"]),
+        ),
+    )
+    con.commit()
+    return new_id
+
+
 def run_staffline_detection(
     job_id: str, cur, con,
     project_id: int, image_id: str, image_name: str, annotation_id: str,
@@ -328,19 +395,14 @@ def run_staffline_detection(
             "package_version": _package_version(),
         }
 
-        new_id = _uuid.uuid4().hex
-        cur.execute(
-            "INSERT INTO staffline_detections"
-            " (id, project_id, image_id, image_name, annotation_id, jsomr_json,"
-            "  scale_unit, stave_count, mode_lines_per_stave, settings_json, status)"
-            " VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,'succeeded')",
-            (
-                new_id, project_id, image_id, image_name, annotation_id,
-                json.dumps(records), scale_unit, len(stave_ids),
-                grouping_result.mode_lines_per_stave, json.dumps(settings),
-            ),
+        new_id = persist_staffline_detection(
+            cur, con, project_id, image_id, image_name, annotation_id,
+            {
+                "records": records, "stave_ids": stave_ids,
+                "grouping_result": grouping_result, "scale_unit": scale_unit,
+                "settings": settings,
+            },
         )
-        con.commit()
 
         # Callers that need to look this row back up right after (e.g.
         # inference_api.py's interpolate-confirm route) should key off this

--- a/landing-page/scripts/staffline_stage.py
+++ b/landing-page/scripts/staffline_stage.py
@@ -328,18 +328,28 @@ def run_staffline_detection(
             "package_version": _package_version(),
         }
 
+        new_id = _uuid.uuid4().hex
         cur.execute(
             "INSERT INTO staffline_detections"
             " (id, project_id, image_id, image_name, annotation_id, jsomr_json,"
             "  scale_unit, stave_count, mode_lines_per_stave, settings_json, status)"
             " VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,'succeeded')",
             (
-                _uuid.uuid4().hex, project_id, image_id, image_name, annotation_id,
+                new_id, project_id, image_id, image_name, annotation_id,
                 json.dumps(records), scale_unit, len(stave_ids),
                 grouping_result.mode_lines_per_stave, json.dumps(settings),
             ),
         )
         con.commit()
+
+        # Callers that need to look this row back up right after (e.g.
+        # inference_api.py's interpolate-confirm route) should key off this
+        # id directly, not re-query "the latest row for this image" --
+        # created_at uses DEFAULT NOW() (transaction-start time, so rows
+        # inserted in the same transaction can share an identical value) and
+        # id is a random uuid4, so neither is a reliable insertion-order
+        # tiebreak on its own.
+        yield {"type": "detection_id", "id": new_id}
 
         message = (
             f"{image_name}: staffline detection found {len(records)} line(s) across "

--- a/landing-page/scripts/staffline_stage.py
+++ b/landing-page/scripts/staffline_stage.py
@@ -181,6 +181,94 @@ def _assemble_jsomr_records(image_name, fit_results, boxes, grouping_result, sca
     return records
 
 
+def _fit_and_group(
+    image_name: str, image_arr: np.ndarray, w: int, h: int, detections, scale_unit: float,
+    interpolate_missing: bool, job_id: Optional[str] = None,
+) -> dict:
+    """Per-box centerline fit + stave grouping -- shared by
+    run_staffline_detection (persisted, tied to a Celery job) and
+    preview_interpolation (unpersisted, synchronous API call, see below).
+
+    job_id is optional: only used to check_cancelled per box when running
+    inside a Celery task (tasks_predict.py's own per-image check_cancelled
+    call only runs once per image; a page with many stave boxes can spend
+    real time in this loop with no cancellation observed in between).
+    Omit it for the preview path, which has no job to cancel.
+
+    Returns a dict with "trace" (already-formatted [trace] message strings,
+    so both callers report identical box-count tracing) always present, and
+    "degenerate": True when every crop was degenerate (mirrors
+    run_staffline_detection's own former early-return -- the caller decides
+    how to report that), else "records"/"stave_ids"/"grouping_result" too.
+    """
+    from component_filter import filter_components
+    from fit_centerline import fit_centerline
+    from group_staves import group_staves
+
+    fit_results = []
+    boxes = []
+    for det in detections:
+        if job_id is not None:
+            check_cancelled(job_id)
+        box = det.to_pixel_box(w, h)
+        crop, actual_box = _crop_with_padding(image_arr, box, CROP_PADDING_PX)
+        if crop.size == 0:
+            continue
+        filter_result = filter_components(crop, scale_unit=scale_unit)
+        fit_result = fit_centerline(filter_result, scale_unit=scale_unit)
+        fit_result.x_page_offset = float(actual_box[0])
+        fit_result.y_page_offset = float(actual_box[1])
+        fit_results.append(fit_result)
+        boxes.append(actual_box)
+
+    trace = [
+        f"[trace] {image_name}: {len(fit_results)}/{len(detections)} box(es) survived crop+fit"
+        f" (non-degenerate)"
+    ]
+    if not fit_results:
+        return {"degenerate": True, "trace": trace}
+
+    grouping_result = group_staves(
+        fit_results, scale_unit=scale_unit, interpolate_missing=interpolate_missing,
+    )
+    records = _assemble_jsomr_records(image_name, fit_results, boxes, grouping_result, scale_unit)
+    stave_ids = {r["stave_id"] for r in records if r["stave_id"] is not None}
+    return {
+        "degenerate": False, "trace": trace,
+        "records": records, "stave_ids": stave_ids, "grouping_result": grouping_result,
+    }
+
+
+def preview_interpolation(image_name: str, image_arr: np.ndarray, yolo_txt: str) -> Optional[list[dict]]:
+    """Synchronous, unpersisted variant for the interpolate-preview API
+    endpoint (inference_api.py's POST .../stafflines/{id}/interpolate-preview).
+    Always runs with interpolate_missing=True, never touches
+    staffline_detections, and has no job to cancel.
+
+    Returns None if there's nothing to preview (no stave-class boxes, or
+    every crop was degenerate) -- callers should treat that as "nothing to
+    interpolate", not an error. Otherwise returns the JSOMR records exactly
+    as run_staffline_detection would have persisted them, for the frontend
+    to render as a preview before the user chooses to accept it (see
+    inference_api.py's interpolate-confirm route, which re-runs and
+    persists for real once accepted)."""
+    from yolo_io import parse_yolo_lines, filter_to_class
+
+    detections = filter_to_class(
+        parse_yolo_lines(yolo_txt.splitlines(), source=f"{image_name} annotation"),
+        STAFFLINE_CLASS_ID,
+    )
+    if not detections:
+        return None
+
+    h, w = image_arr.shape[:2]
+    scale_unit = _compute_page_scale_unit(detections, w, h)
+    result = _fit_and_group(image_name, image_arr, w, h, detections, scale_unit, interpolate_missing=True)
+    if result["degenerate"]:
+        return None
+    return result["records"]
+
+
 def run_staffline_detection(
     job_id: str, cur, con,
     project_id: int, image_id: str, image_name: str, annotation_id: str,
@@ -195,19 +283,15 @@ def run_staffline_detection(
     interpolate_missing is plumbed through, default off, matching
     staff-finding/dox/STATUS.md's "not yet validated across the corpus"
     caveat -- flipping it later is a default change, not a re-plumbing job.
+    (See preview_interpolation() above for the opt-in, review-before-persist
+    path the frontend actually uses to turn this on per-image.)
 
-    tasks_predict.py's own per-image check_cancelled(job_id) call only runs
-    once per image; a page with many stave boxes can spend real time in the
-    per-box loop below with no cancellation observed in between, so this
-    checks again on every box. JobCancelled is deliberately re-raised, not
-    swallowed by the broad except below -- a cancelled job must actually
-    stop, not be recorded as one failed staffline-detection attempt among
-    many while the outer per-image loop keeps going.
+    JobCancelled is deliberately re-raised, not swallowed by the broad
+    except below -- a cancelled job must actually stop, not be recorded as
+    one failed staffline-detection attempt among many while the outer
+    per-image loop keeps going.
     """
     from yolo_io import parse_yolo_lines, filter_to_class
-    from component_filter import filter_components
-    from fit_centerline import fit_centerline
-    from group_staves import group_staves
 
     detections = filter_to_class(
         parse_yolo_lines(yolo_txt.splitlines(), source=f"{image_name} annotation"),
@@ -223,37 +307,20 @@ def run_staffline_detection(
     scale_unit = _compute_page_scale_unit(detections, w, h)
 
     try:
-        fit_results = []
-        boxes = []
-        for det in detections:
-            check_cancelled(job_id)
-            box = det.to_pixel_box(w, h)
-            crop, actual_box = _crop_with_padding(image_arr, box, CROP_PADDING_PX)
-            if crop.size == 0:
-                continue
-            filter_result = filter_components(crop, scale_unit=scale_unit)
-            fit_result = fit_centerline(filter_result, scale_unit=scale_unit)
-            fit_result.x_page_offset = float(actual_box[0])
-            fit_result.y_page_offset = float(actual_box[1])
-            fit_results.append(fit_result)
-            boxes.append(actual_box)
+        result = _fit_and_group(image_name, image_arr, w, h, detections, scale_unit, interpolate_missing, job_id=job_id)
+        for msg in result["trace"]:
+            yield {"type": "log", "message": msg}
 
-        yield {"type": "log", "message":
-               f"[trace] {image_name}: {len(fit_results)}/{len(detections)} box(es) survived crop+fit"
-               f" (non-degenerate)"}
-
-        if not fit_results:
+        if result["degenerate"]:
             yield {
                 "type": "log",
                 "message": f"{image_name}: {len(detections)} stave box(es) found but all crops were degenerate; skipping staffline detection",
             }
             return
 
-        grouping_result = group_staves(
-            fit_results, scale_unit=scale_unit, interpolate_missing=interpolate_missing,
-        )
-        records = _assemble_jsomr_records(image_name, fit_results, boxes, grouping_result, scale_unit)
-        stave_ids = {r["stave_id"] for r in records if r["stave_id"] is not None}
+        records = result["records"]
+        stave_ids = result["stave_ids"]
+        grouping_result = result["grouping_result"]
         settings = {
             "interpolate_missing": interpolate_missing,
             "binarization": "sauvola",

--- a/landing-page/scripts/staffline_stage.py
+++ b/landing-page/scripts/staffline_stage.py
@@ -216,6 +216,9 @@ def run_staffline_detection(
     if not detections:
         return
 
+    yield {"type": "log", "message":
+           f"[trace] {image_name}: {len(detections)} raw stave-class box(es) parsed from YOLO annotation"}
+
     h, w = image_arr.shape[:2]
     scale_unit = _compute_page_scale_unit(detections, w, h)
 
@@ -234,6 +237,10 @@ def run_staffline_detection(
             fit_result.y_page_offset = float(actual_box[1])
             fit_results.append(fit_result)
             boxes.append(actual_box)
+
+        yield {"type": "log", "message":
+               f"[trace] {image_name}: {len(fit_results)}/{len(detections)} box(es) survived crop+fit"
+               f" (non-degenerate)"}
 
         if not fit_results:
             yield {

--- a/landing-page/scripts/tasks_encode.py
+++ b/landing-page/scripts/tasks_encode.py
@@ -174,7 +174,9 @@ def _encode_one(publish, xml_bytes, xml_filename, image_bytes, image_filename,
             else:
                 ev({"type": "log", "message": f" estimated {len(staves)} stave(s) from glyph positions"})
         n_input_staves = len(staves)
-        glyphs_by_stave, staves = assign_glyphs_to_staves(glyphs, staves, page_w, page_h)
+        glyphs_by_stave, staves = assign_glyphs_to_staves(
+            glyphs, staves, page_w, page_h, allow_synthetic_lines=allow_synthetic_lines,
+        )
         if len(staves) > n_input_staves:
             ev({"type": "log", "message":
                 f" recovered {len(staves) - n_input_staves} stave(s) the detector missed"})

--- a/landing-page/scripts/tasks_encode.py
+++ b/landing-page/scripts/tasks_encode.py
@@ -104,7 +104,7 @@ def _resolve_hints(project_id: Optional[int], image_name: Optional[str], page_w,
 
 def _encode_one(publish, xml_bytes, xml_filename, image_bytes, image_filename,
                 project_id, image_name, clef_shape, clef_line, item=None,
-                include_name_fields=False):
+                include_name_fields=False, allow_synthetic_lines=False):
     """Runs the checking/validating/processing pipeline for one XML+image
     pair, publishing the same event sequence the old synchronous generator
     yielded. Returns (session_id, result_payload)."""
@@ -149,8 +149,19 @@ def _encode_one(publish, xml_bytes, xml_filename, image_bytes, image_filename,
             label = "staffline detection" if stave_source == "staffline_detection" else "YOLO annotations"
             ev({"type": "log", "message": f" {len(staves)} stave(s) from {label}"})
         else:
-            staves = estimate_staves_from_glyphs(glyphs, page_w, page_h)
-            ev({"type": "log", "message": f" estimated {len(staves)} stave(s) from glyph positions"})
+            staves, stave_source = estimate_staves_from_glyphs(
+                glyphs, page_w, page_h, allow_synthetic_lines=allow_synthetic_lines,
+            )
+            if stave_source == "placeholder_no_glyphs":
+                ev({"type": "log", "message":
+                    " [warn] no glyphs at all -- stave geometry is a full-page placeholder, not a real detection"})
+            elif stave_source == "glyph_estimate_unresolved_lines":
+                ev({"type": "log", "message":
+                    f" [warn] estimated {len(staves)} stave(s) from glyph positions, but too few real staff-line"
+                    " glyphs to resolve pitch -- notes on these staves default to unresolved pitch (a3)."
+                    " Pass allow_synthetic_lines to fabricate plausible-looking lines instead."})
+            else:
+                ev({"type": "log", "message": f" estimated {len(staves)} stave(s) from glyph positions"})
         n_input_staves = len(staves)
         glyphs_by_stave, staves = assign_glyphs_to_staves(glyphs, staves, page_w, page_h)
         if len(staves) > n_input_staves:
@@ -187,7 +198,7 @@ def _encode_one(publish, xml_bytes, xml_filename, image_bytes, image_filename,
         manifest = build_neon_manifest(mei_bytes_out, image_data_uri or str(image_ref), stem) if image_data_uri else None
         session_put(session_id, mei_bytes_out, stem, manifest)
 
-        result = {"session_id": session_id, "mei_base64": mei_b64, "manifest": manifest}
+        result = {"session_id": session_id, "mei_base64": mei_b64, "manifest": manifest, "stave_source": stave_source}
         if include_name_fields:
             result["image_name"] = image_filename
             result["stem"] = stem
@@ -199,7 +210,8 @@ def _encode_one(publish, xml_bytes, xml_filename, image_bytes, image_filename,
 
 @celery_app.task(name="encode.upload")
 def run_encode_upload_task(job_id, xml_upload_id, xml_filename, image_upload_id,
-                           image_filename, project_id, image_name, clef_shape, clef_line):
+                           image_filename, project_id, image_name, clef_shape, clef_line,
+                           allow_synthetic_lines=False):
     def publish(obj):
         publish_event(job_id, obj)
 
@@ -207,7 +219,8 @@ def run_encode_upload_task(job_id, xml_upload_id, xml_filename, image_upload_id,
     image_bytes = fetch_upload(image_upload_id) if image_upload_id else None
     try:
         _encode_one(publish, xml_bytes, xml_filename, image_bytes, image_filename,
-                    project_id, image_name, clef_shape, clef_line, include_name_fields=False)
+                    project_id, image_name, clef_shape, clef_line, include_name_fields=False,
+                    allow_synthetic_lines=allow_synthetic_lines)
         publish({"type": "done"})
         drop_upload(xml_upload_id)
         if image_upload_id:
@@ -217,10 +230,11 @@ def run_encode_upload_task(job_id, xml_upload_id, xml_filename, image_upload_id,
         # leave the upload rows in place so a retry can still fetch them
 
 @celery_app.task(name="encode.batch")
-def run_encode_batch_task(job_id, items, project_id, clef_shape, clef_line):
+def run_encode_batch_task(job_id, items, project_id, clef_shape, clef_line,
+                           allow_synthetic_lines=False):
     def publish(obj):
         publish_event(job_id, obj)
-    
+
     succeeded, failed = [], []
     for i, item in enumerate(items):
         check_cancelled(job_id)
@@ -232,7 +246,7 @@ def run_encode_batch_task(job_id, items, project_id, clef_shape, clef_line):
             session_id, _ = _encode_one(
                 publish, xml_bytes, item["xml_filename"], image_bytes, item["image_filename"],
                 project_id, item["image_name"], clef_shape, clef_line,
-                item=i, include_name_fields=True,
+                item=i, include_name_fields=True, allow_synthetic_lines=allow_synthetic_lines,
             )
             succeeded.append({"item": i, "session_id": session_id,
                                "name": item["image_filename"] or item["xml_filename"]})

--- a/landing-page/scripts/tasks_encode.py
+++ b/landing-page/scripts/tasks_encode.py
@@ -15,7 +15,7 @@ from auth_api import get_db_conn, release_db_conn
 from encode_to_mei import (
     parse_gamera_xml, assign_glyphs_to_staves, estimate_staves_from_glyphs,
     parse_yolo_stave_hints, build_mei, build_neon_manifest, validate_mei,
-    image_dimensions, scale_facsimile,
+    image_dimensions, scale_facsimile, trace_stave_zone_parity,
 )
 import staffline_adapter
 
@@ -38,7 +38,7 @@ def _fetch_original_bytes(project_id: Optional[int], image_name: Optional[str]) 
     finally:
         release_db_conn(con)
 
-def _resolve_hints(project_id: Optional[int], image_name: Optional[str], page_w, page_h):
+def _resolve_hints(project_id: Optional[int], image_name: Optional[str], page_w, page_h, ev=None):
     """Looks up saved text-alignment + stave annotations for one image.
     Falls back to None/[]/None on any lookup failure or missing
     project_id/image_name, mirroring the try/except-pass behavior of the
@@ -50,7 +50,14 @@ def _resolve_hints(project_id: Optional[int], image_name: Optional[str], page_w,
     staffline_detections data (tier 1, when a project has it) wins over the
     coarser yolo_txt-geometry heuristic in parse_yolo_stave_hints (tier 2,
     today's only source, still the fallback for projects/images that predate
-    this feature or whose staffline detection failed/was skipped)."""
+    this feature or whose staffline detection failed/was skipped).
+
+    ev, if given, is _encode_one's own event-publishing closure -- used here
+    only to emit [trace] lines confirming staves_from_jsomr()'s input/output
+    record counts (and whether any stave fell back to its centerline-derived
+    bbox instead of a real detected one), so a silent drop between the
+    stored JSOMR and the StaveBbox list handed to build_mei() is directly
+    visible in the job log, not just inferred from code review."""
     text_alignment = None
     yolo_stave_hints = []
     stave_source = None
@@ -81,6 +88,10 @@ def _resolve_hints(project_id: Optional[int], image_name: Optional[str], page_w,
                     yolo_stave_hints = staffline_adapter.staves_from_jsomr(jsomr_records)
                     if yolo_stave_hints:
                         stave_source = "staffline_detection"
+                    if ev:
+                        ev({"type": "log", "message":
+                            f"[trace] {image_name}: staves_from_jsomr: {len(jsomr_records)} JSOMR record(s) in"
+                            f" -> {len(yolo_stave_hints)} stave(s) out"})
             except Exception:
                 pass
             if not yolo_stave_hints:
@@ -141,7 +152,7 @@ def _encode_one(publish, xml_bytes, xml_filename, image_bytes, image_filename,
         ev({"type": "stage_done", "name": "checking"})
 
         ev({"type": "stage", "name": "validating"})
-        text_alignment, yolo_stave_hints, stave_source = _resolve_hints(project_id, image_name, page_w, page_h)
+        text_alignment, yolo_stave_hints, stave_source = _resolve_hints(project_id, image_name, page_w, page_h, ev=ev)
         if text_alignment:
             ev({"type": "log", "message": f" {len(text_alignment.get('syl_boxes', []))} syllable(s) from text-finding"})
         if yolo_stave_hints:
@@ -180,6 +191,8 @@ def _encode_one(publish, xml_bytes, xml_filename, image_bytes, image_filename,
             clef_line=clef_line or 3,
             text_alignment=text_alignment,
         )
+        for msg in trace_stave_zone_parity(staves, mei_bytes_out):
+            ev({"type": "log", "message": msg})
         original_bytes = _fetch_original_bytes(project_id, image_name)
         if original_bytes and page_w:
             try:

--- a/landing-page/scripts/tasks_predict.py
+++ b/landing-page/scripts/tasks_predict.py
@@ -154,6 +154,9 @@ def run_predict_task(job_id, project_id, body):
             # a staffline_detections row. Ordered before the has_text_alignment
             # check below so its continue can never skip this block.
             if has_class(yolo_txt, STAFFLINE_CLASS_ID):
+                publish({"type": "log", "message":
+                    f"[trace] {image_name}: stave-class boxes came from model"
+                    f" '{yolo_models.model_label}' (hash {yolo_models.model_hash or 'n/a'})"})
                 for sf_ev in run_staffline_detection(
                     job_id, cur, con, project_id, image_id, image_name, ann_id, img_arr, yolo_txt,
                 ):

--- a/landing-page/scripts/tasks_text_batch.py
+++ b/landing-page/scripts/tasks_text_batch.py
@@ -118,6 +118,9 @@ def run_text_batch_task(job_id, project_id, body):
             # documentation_allons-y/STAFFLINE_INTEGRATION_FOLLOWUPS.md's
             # "batch_api.py's text-batch-run path" bullet).
             if has_class(yolo_txt, STAFFLINE_CLASS_ID):
+                publish({"type": "log", "message":
+                    f"[trace] {name}: stave-class boxes came from model"
+                    f" '{yolo_models.model_label}' (hash {yolo_models.model_hash or 'n/a'})"})
                 for sf_ev in run_staffline_detection(
                     job_id, cur, con, project_id, image_id, name, ann_id, img_arr, yolo_txt,
                 ):

--- a/landing-page/scripts/tests/test_bbox_pipeline_integrity.py
+++ b/landing-page/scripts/tests/test_bbox_pipeline_integrity.py
@@ -1,0 +1,105 @@
+"""Backs up the [trace] job-log instrumentation added alongside these tests
+with real assertions, not just log lines someone has to read -- "bbox
+information is carried securely to Neon without being overridden."
+
+Starts from a hand-built JSOMR record set (same fixture style as
+test_staffline_adapter.py) rather than a raw YOLO stave-boxes .txt: the
+actual detection stage (staffline_stage.run_staffline_detection) imports
+job_store -> auth_api, which connects to Postgres at import time (see
+auth_api.py's module-level init_db() call) -- exactly the constraint
+test_staffline_adapter.py's own docstring sidesteps by never importing
+staffline_stage either. JSOMR is the next stage down (it's literally what
+staffline_detections.jsomr_json stores), so this still covers the real
+handoff this session's tracing cares about: stored detection data ->
+staffline_adapter.staves_from_jsomr() -> encode_to_mei.build_mei() -> the
+MEI zones Neon actually loads.
+
+No DB, no Celery, no cv2/scipy/scikit-image.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from staffline_adapter import staves_from_jsomr  # noqa: E402
+from encode_to_mei import assign_glyphs_to_staves, build_mei, trace_stave_zone_parity  # noqa: E402
+from medieval_models import STAVE_FILENAME, STAVE_CLASS_MAP  # noqa: E402
+
+
+def _line(stave_id, within_stave_index, x_start, x_end, y_values, ulx, uly, lrx, lry):
+    """Same shape as test_staffline_adapter.py's _line(), trimmed to what
+    this file needs (always a real detected box -- no interpolated-line
+    cases here, that's already covered there)."""
+    centerline_page = {"x_start": x_start, "x_end": x_end, "y_values": list(y_values)}
+    return {
+        "id": f"test_s{stave_id}_l{within_stave_index}",
+        "source": "detected",
+        "bounding_box": {"ulx": ulx, "uly": uly, "lrx": lrx, "lry": lry},
+        "centerline": centerline_page,
+        "centerline_page": centerline_page,
+        "fit": {"method": "quadratic_huber", "coefficients": [0, 0, y_values[0]],
+                "residual_mean": 0.1, "residual_max": 0.2,
+                "n_pixels_used": len(y_values), "n_pixels_total": len(y_values)},
+        "quality": {"confidence": None, "flags": []},
+        "scale_unit": 10.0,
+        "column_id": None,
+        "stave_id": stave_id,
+        "lines_detected": None, "lines_interpolated": None, "lines_expected": None,
+        "rhythm_status": None,
+        "within_stave_index": within_stave_index,
+    }
+
+
+def test_jsomr_to_mei_zones_survive_unchanged():
+    """Two staves' worth of JSOMR records -> staves_from_jsomr() ->
+    build_mei() -> parse the MEI zones back out and confirm they're
+    byte-for-byte the same coordinates staves_from_jsomr() produced -- the
+    exact integrity trace_stave_zone_parity() checks on every real encode."""
+    records = []
+    for i, y in enumerate([100, 120, 140, 160]):
+        records.append(_line(0, i, 0, 700, [y] * 701, 50, y - 5, 750, y + 5))
+    for i, y in enumerate([300, 320, 340]):
+        records.append(_line(1, i, 0, 700, [y] * 701, 50, y - 5, 750, y + 5))
+
+    staves = staves_from_jsomr(records)
+    assert len(staves) == 2
+
+    glyphs_by_stave, staves = assign_glyphs_to_staves([], staves, page_w=900, page_h=1300)
+    mei_bytes = build_mei(glyphs_by_stave, staves, Path("page.jpg"), 900, 1300, "test")
+
+    trace = trace_stave_zone_parity(staves, mei_bytes)
+    assert len(trace) == 1
+    assert "verified identical" in trace[0]
+    assert "[warn]" not in trace[0]
+
+
+def test_trace_flags_a_genuine_divergence():
+    """Sanity check on trace_stave_zone_parity() itself: if the StaveBbox
+    list handed to it doesn't match what's actually in the MEI (simulating
+    something silently mutating stave geometry between resolution and
+    encoding), it must say so loudly, not pass silently."""
+    records = [_line(0, 0, 0, 700, [100] * 701, 50, 95, 750, 105)]
+    staves = staves_from_jsomr(records)
+    glyphs_by_stave, staves = assign_glyphs_to_staves([], staves, page_w=900, page_h=1300)
+    mei_bytes = build_mei(glyphs_by_stave, staves, Path("page.jpg"), 900, 1300, "test")
+
+    tampered = [s for s in staves]
+    tampered[0].ulx = 99999  # pretend something moved this stave after encoding
+
+    trace = trace_stave_zone_parity(tampered, mei_bytes)
+    assert len(trace) == 1
+    assert "[warn]" in trace[0]
+    assert "diverged" in trace[0]
+
+
+def test_medieval_stave_model_still_points_at_expected_checkpoint():
+    """Catches a future accidental repoint of the bundled stave detector (or
+    its merged-class-space slot) silently -- see CLAUDE.md's "Updating the
+    bundled medieval models" section for how/why these would ever change."""
+    assert STAVE_FILENAME == "stave_detector_fulldata.pt"
+    assert STAVE_CLASS_MAP == {0: 2}  # single class -> merged slot 2 ("staves")
+
+
+if __name__ == "__main__":
+    import pytest
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/landing-page/src/components/AppRouter.tsx
+++ b/landing-page/src/components/AppRouter.tsx
@@ -78,7 +78,13 @@ interface AppRouterProps {
   handleLoginSuccess: (user: CurrentUser, token: string) => void;
   handleLogout: () => void;
   mutations: ReturnType<typeof useProjectMutations>;
-  handleEncodeResult: (ev: { session_id: string; mei_base64: string; manifest: Record<string, unknown> | null }) => void;
+  handleEncodeResult: (ev: {
+    session_id: string;
+    mei_base64: string;
+    manifest: Record<string, unknown> | null;
+    stave_source?: string | null;
+    logs?: string[];
+  }) => void;
   pendingBatchPairs: { xmlFile: File; imageFile: File }[];
   setPendingBatchPairs: (pairs: { xmlFile: File; imageFile: File }[]) => void;
   handleEncodeBatchResult: (ev: {
@@ -88,6 +94,8 @@ interface AppRouterProps {
     manifest: Record<string, unknown> | null;
     image_name?: string;
     stem?: string;
+    stave_source?: string | null;
+    logs?: string[];
   }) => void;
 }
 

--- a/landing-page/src/components/project/MeiViewerModal.tsx
+++ b/landing-page/src/components/project/MeiViewerModal.tsx
@@ -1,4 +1,4 @@
-import type { MeiFile } from "../../types";
+import type { MeiFile, StaveSource } from "../../types";
 import { downloadBlob } from "../../utils/download";
 import TruncatedName from "../shared/TruncatedName";
 
@@ -7,6 +7,20 @@ interface Props {
     onClose: () => void;
 }
 
+// Which of tasks_encode.py's 3-tier fallback produced this MEI's zones --
+// real detected geometry vs. a fallback vs. a true placeholder. Badge color
+// mirrors StafflineViewerModal's anomaly-flag language (blue = worth a
+// second look), reserving the strongest color for the one case that means
+// "no real stave geometry at all".
+const STAVE_SOURCE_LABELS: Record<StaveSource, { label: string; className: string }> = {
+    staffline_detection: { label: "real staffline detection", className: "text-[#1E6B70]" },
+    yolo_annotation: { label: "YOLO annotation geometry", className: "text-[#1E6B70]" },
+    glyph_estimate: { label: "estimated from glyphs", className: "text-[#1D3335]/60" },
+    glyph_estimate_unresolved_lines: { label: "estimated -- pitch unresolved", className: "text-[#2563EB]" },
+    glyph_estimate_synthetic_lines: { label: "estimated -- synthetic lines", className: "text-[#2563EB]" },
+    placeholder_no_glyphs: { label: "placeholder (no glyphs found)", className: "text-[#FF3B30]" },
+};
+
 export default function MeiViewerModal({ file, onClose }: Props) {
     const handleExport = () => {
         downloadBlob(
@@ -14,6 +28,7 @@ export default function MeiViewerModal({ file, onClose }: Props) {
             file.name,
         );
     }
+    const staveSourceInfo = file.staveSource ? STAVE_SOURCE_LABELS[file.staveSource] : null;
 
     return (
         <>
@@ -25,6 +40,11 @@ export default function MeiViewerModal({ file, onClose }: Props) {
                     name={file.name}
                     className="font-mono text-sm text-[#1D3335] font-semibold flex-1 min-w-0"
                 />
+                {staveSourceInfo && (
+                    <span className={`text-xs font-semibold whitespace-nowrap ${staveSourceInfo.className}`}>
+                        {staveSourceInfo.label}
+                    </span>
+                )}
                 <button
                     onClick={handleExport}
                     className="px-4 py-1.5 bg-white text-[#1D3335] font-semibold rounded-xl hover:opacity-90 cursor-pointer text-sm"

--- a/landing-page/src/components/project/ProjectDetail.tsx
+++ b/landing-page/src/components/project/ProjectDetail.tsx
@@ -665,6 +665,12 @@ export default function ProjectDetail({
                     stafflines={project.stafflines}
                     images={project.images}
                     projectId={project.id}
+                    onAddStaffline={(newSet) =>
+                      onUpdateProject({
+                        ...project,
+                        stafflines: [...project.stafflines, newSet],
+                      })
+                    }
                   />
                 )}
                 {generatedSubTab === "mei files" && (

--- a/landing-page/src/components/project/RhythmChart.tsx
+++ b/landing-page/src/components/project/RhythmChart.tsx
@@ -8,7 +8,9 @@ import { type RhythmGapSummary } from "../../lib/rhythmGaps";
 // for a single visual.
 
 const PALETTE = ["#4AADAA", "#FFA500", "#E87BF7", "#F76B6B", "#6BF7A5", "#F7E16B"];
-const ANOMALY_COLOR = "#FF3B30";
+// Matches StafflineViewerModal's own ANOMALY_COLOR -- blue rather than red,
+// which read as noise against these manuscripts' red rubrics/staff-lines.
+const ANOMALY_COLOR = "#2563EB";
 const NOISE_FLOOR_COLOR = "#1D3335";
 const CUT_THRESHOLD_COLOR = "#FF3B30";
 const MAX_INTERP_COLOR = "#FFA500";
@@ -143,7 +145,7 @@ export default function RhythmChart({ summary }: Props) {
           <span className="text-[#FFA500]">┅</span> max interp. gap ({maxInterpGapPx.toFixed(1)}px)
         </span>
         <span>
-          <span className="text-[#FF3B30]">■</span> flagged stave
+          <span className="text-[#2563EB]">■</span> flagged stave
         </span>
       </div>
       <p className="mt-2 text-[#1D3335]/50 text-[11px] font-mono">

--- a/landing-page/src/components/project/StafflineViewerModal.tsx
+++ b/landing-page/src/components/project/StafflineViewerModal.tsx
@@ -338,7 +338,10 @@ export default function StafflineViewerModal({ detection, projectId, onClose, la
                     </button>
                 </div>
                 {interpolateError && (
-                    <div className="px-6 py-2 bg-[#FF3B30]/10 text-[#FF3B30] text-xs font-mono border-b border-[#1D3335]/10">
+                    <div
+                        role="alert"
+                        className="px-6 py-2 bg-[#FF3B30]/10 text-[#FF3B30] text-xs font-mono border-b border-[#1D3335]/10"
+                    >
                         {interpolateError}
                     </div>
                 )}

--- a/landing-page/src/components/project/StafflineViewerModal.tsx
+++ b/landing-page/src/components/project/StafflineViewerModal.tsx
@@ -24,14 +24,27 @@ interface Props {
     projectId: number;
     onClose: () => void;
     label?: string;
+    // Called once a previewed interpolation is accepted and persisted as a
+    // new staffline_detections row -- lets the caller (StafflinesTab) merge
+    // it into project.stafflines and swap this modal's `detection` prop to
+    // show it, without a full project refetch.
+    onAccepted?: (newSet: StafflineSet) => void;
 }
 
-export default function StafflineViewerModal({ detection, projectId, onClose, label }: Props) {
+export default function StafflineViewerModal({ detection, projectId, onClose, label, onAccepted }: Props) {
     const [viewState, setViewState] = useState<ViewState>({ status: "loading" });
     const [notesOpen, setNotesOpen] = useState(false);
     const [tab, setTab] = useState<"overlay" | "rhythm" | "raw">("overlay");
     const [copied, setCopied] = useState(false);
     const [copyFailed, setCopyFailed] = useState(false);
+    // Non-null once interpolate-preview has returned -- presence alone means
+    // "we're reviewing a preview", not yet persisted. interpolate_missing is
+    // "not yet validated across the corpus" (staff-finding/dox/STATUS.md),
+    // hence review-before-persist rather than a one-click apply.
+    const [interpolatePreview, setInterpolatePreview] = useState<JsomrLineRecord[] | null>(null);
+    const [previewLoading, setPreviewLoading] = useState(false);
+    const [confirmLoading, setConfirmLoading] = useState(false);
+    const [interpolateError, setInterpolateError] = useState<string | null>(null);
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const imgRef = useRef<HTMLImageElement>(null);
 
@@ -65,17 +78,26 @@ export default function StafflineViewerModal({ detection, projectId, onClose, la
         [viewState],
     );
 
-    const anomalousStaveIds =
-        viewState.status === "ready"
-            ? new Set(
-                  viewState.records
-                      .filter((r) => r.rhythm_status && r.stave_id !== null)
-                      .map((r) => r.stave_id as number),
-              )
-            : new Set<number>();
+    // While previewing, the overlay draws the previewed (unpersisted) records
+    // instead of the real detection's -- everything downstream of this single
+    // switch (anomaly flags, the canvas overlay, the notes list) just works
+    // off whichever set is active. Memoized so drawOverlay's own useCallback
+    // deps don't churn on every render.
+    const activeRecords: JsomrLineRecord[] = useMemo(
+        () => interpolatePreview ?? (viewState.status === "ready" ? viewState.records : []),
+        [interpolatePreview, viewState],
+    );
+
+    const anomalousStaveIds = useMemo(
+        () => new Set(
+            activeRecords
+                .filter((r) => r.rhythm_status && r.stave_id !== null)
+                .map((r) => r.stave_id as number),
+        ),
+        [activeRecords],
+    );
 
     const drawOverlay = useCallback(() => {
-        if (viewState.status !== "ready") return;
         const canvas = canvasRef.current;
         const img = imgRef.current;
         if (!canvas || !img || !img.naturalWidth) return;
@@ -88,7 +110,7 @@ export default function StafflineViewerModal({ detection, projectId, onClose, la
         const ctx = canvas.getContext("2d")!;
         ctx.clearRect(0, 0, dw, dh);
 
-        viewState.records.forEach((r) => {
+        activeRecords.forEach((r) => {
             const isAnomalous = r.stave_id !== null && anomalousStaveIds.has(r.stave_id);
             const color = isAnomalous
                 ? ANOMALY_COLOR
@@ -124,12 +146,24 @@ export default function StafflineViewerModal({ detection, projectId, onClose, la
             ctx.stroke();
         });
         ctx.setLineDash([]);
-    }, [viewState, anomalousStaveIds]);
+    }, [activeRecords, anomalousStaveIds]);
+
+    // The image itself doesn't reload when only interpolatePreview changes
+    // (same detection, same imageUrl), so re-draw explicitly rather than
+    // relying solely on the <img>'s onLoad, which won't fire again.
+    useEffect(() => {
+        drawOverlay();
+    }, [drawOverlay]);
 
     useEffect(() => {
         let disposed = false;
         let imageUrl: string | undefined;
         setViewState({ status: "loading" });
+        // A fresh detection (e.g. onAccepted swapping in the just-confirmed
+        // one) means any prior preview is stale -- clear it rather than
+        // showing last detection's preview over this one's image.
+        setInterpolatePreview(null);
+        setInterpolateError(null);
 
         if (!detection.imageSrc) {
             setViewState({ status: "error", message: "No image source for this detection." });
@@ -171,16 +205,61 @@ export default function StafflineViewerModal({ detection, projectId, onClose, la
         };
     }, [detection.id, detection.imageSrc, projectId]);
 
-    const anomalyNotes =
-        viewState.status === "ready"
-            ? Array.from(
-                  new Map(
-                      viewState.records
-                          .filter((r) => r.rhythm_status && r.stave_id !== null)
-                          .map((r) => [r.stave_id, r.rhythm_status as string]),
-                  ),
-              )
-            : [];
+    const anomalyNotes = Array.from(
+        new Map(
+            activeRecords
+                .filter((r) => r.rhythm_status && r.stave_id !== null)
+                .map((r) => [r.stave_id, r.rhythm_status as string]),
+        ),
+    );
+
+    const handlePreviewInterpolation = async () => {
+        setInterpolateError(null);
+        setPreviewLoading(true);
+        try {
+            const r = await apiFetch(
+                `/api/projects/${projectId}/stafflines/${detection.id}/interpolate-preview`,
+                { method: "POST" },
+            );
+            if (!r.ok) {
+                const d = await r.json().catch(() => ({}));
+                throw new Error((d as { detail?: string }).detail || "interpolation preview failed");
+            }
+            const data = await r.json();
+            setInterpolatePreview((data as { jsomrJson: JsomrLineRecord[] }).jsomrJson ?? []);
+        } catch (e) {
+            setInterpolateError((e as Error).message);
+        } finally {
+            setPreviewLoading(false);
+        }
+    };
+
+    const handleDiscardInterpolation = () => {
+        setInterpolatePreview(null);
+        setInterpolateError(null);
+    };
+
+    const handleAcceptInterpolation = async () => {
+        setInterpolateError(null);
+        setConfirmLoading(true);
+        try {
+            const r = await apiFetch(
+                `/api/projects/${projectId}/stafflines/${detection.id}/interpolate-confirm`,
+                { method: "POST" },
+            );
+            if (!r.ok) {
+                const d = await r.json().catch(() => ({}));
+                throw new Error((d as { detail?: string }).detail || "interpolation failed");
+            }
+            const newSet = (await r.json()) as StafflineSet;
+            setInterpolatePreview(null);
+            onAccepted?.(newSet);
+        } catch (e) {
+            setInterpolateError((e as Error).message);
+        } finally {
+            setConfirmLoading(false);
+        }
+    };
 
     return (
         <>
@@ -201,24 +280,55 @@ export default function StafflineViewerModal({ detection, projectId, onClose, la
                             {anomalousStaveIds.size} flagged for review
                         </span>
                     )}
-                    {viewState.status === "ready" && (
-                        <div className="flex bg-[#1D3335]/10 rounded-full p-0.5 text-xs font-mono">
-                            {(rhythmSummary ? (["overlay", "rhythm", "raw"] as const) : (["overlay", "raw"] as const)).map(
-                                (t) => (
-                                    <button
-                                        key={t}
-                                        onClick={() => setTab(t)}
-                                        className={`px-3 py-1 rounded-full cursor-pointer transition-colors ${
-                                            tab === t
-                                                ? "bg-[#1D3335] text-white"
-                                                : "text-[#1D3335]/60 hover:text-[#1D3335]"
-                                        }`}
-                                    >
-                                        {t}
-                                    </button>
-                                ),
-                            )}
+                    {interpolatePreview ? (
+                        <div className="flex items-center gap-2">
+                            <span className="text-xs font-mono text-[#2563EB] italic">reviewing preview</span>
+                            <button
+                                onClick={handleDiscardInterpolation}
+                                disabled={confirmLoading}
+                                className="px-3 py-1 rounded-full text-xs font-mono border border-[#1D3335]/30 text-[#1D3335]/70 hover:text-[#1D3335] cursor-pointer disabled:opacity-50"
+                            >
+                                discard
+                            </button>
+                            <button
+                                onClick={handleAcceptInterpolation}
+                                disabled={confirmLoading}
+                                className="px-3 py-1 rounded-full text-xs font-mono bg-[#2563EB] text-white hover:opacity-90 cursor-pointer disabled:opacity-50"
+                            >
+                                {confirmLoading ? "accepting..." : "accept"}
+                            </button>
                         </div>
+                    ) : (
+                        <>
+                            {anomalousStaveIds.size > 0 && viewState.status === "ready" && (
+                                <button
+                                    onClick={handlePreviewInterpolation}
+                                    disabled={previewLoading}
+                                    className="px-3 py-1 rounded-full text-xs font-mono border border-[#2563EB] text-[#2563EB] hover:bg-[#2563EB]/10 cursor-pointer disabled:opacity-50"
+                                >
+                                    {previewLoading ? "computing preview..." : "interpolate missing lines"}
+                                </button>
+                            )}
+                            {viewState.status === "ready" && (
+                                <div className="flex bg-[#1D3335]/10 rounded-full p-0.5 text-xs font-mono">
+                                    {(rhythmSummary ? (["overlay", "rhythm", "raw"] as const) : (["overlay", "raw"] as const)).map(
+                                        (t) => (
+                                            <button
+                                                key={t}
+                                                onClick={() => setTab(t)}
+                                                className={`px-3 py-1 rounded-full cursor-pointer transition-colors ${
+                                                    tab === t
+                                                        ? "bg-[#1D3335] text-white"
+                                                        : "text-[#1D3335]/60 hover:text-[#1D3335]"
+                                                }`}
+                                            >
+                                                {t}
+                                            </button>
+                                        ),
+                                    )}
+                                </div>
+                            )}
+                        </>
                     )}
                     <button
                         onClick={onClose}
@@ -227,6 +337,11 @@ export default function StafflineViewerModal({ detection, projectId, onClose, la
                         ✕
                     </button>
                 </div>
+                {interpolateError && (
+                    <div className="px-6 py-2 bg-[#FF3B30]/10 text-[#FF3B30] text-xs font-mono border-b border-[#1D3335]/10">
+                        {interpolateError}
+                    </div>
+                )}
                 <div className="flex-1 min-h-0 overflow-auto">
                     {viewState.status === "loading" ? (
                         <div className="flex items-center justify-center h-full text-[#1D3335]/60 text-sm">
@@ -236,11 +351,11 @@ export default function StafflineViewerModal({ detection, projectId, onClose, la
                         <div className="flex items-center justify-center h-full text-[#1D3335]/60 text-sm">
                             {viewState.message}
                         </div>
-                    ) : tab === "rhythm" && rhythmSummary ? (
+                    ) : !interpolatePreview && tab === "rhythm" && rhythmSummary ? (
                         <div className="p-4">
                             <RhythmChart summary={rhythmSummary} />
                         </div>
-                    ) : tab === "raw" ? (
+                    ) : !interpolatePreview && tab === "raw" ? (
                         <div className="p-4">
                             <div className="flex items-center justify-end gap-3 mb-2">
                                 <button
@@ -276,7 +391,9 @@ export default function StafflineViewerModal({ detection, projectId, onClose, la
                                 />
                             </div>
                             <p className="mt-2 text-[#1D3335]/50 text-[11px] font-mono">
-                                dashed = interpolated · gray = unassigned · blue = flagged for review
+                                {interpolatePreview
+                                    ? "previewing unpersisted interpolated lines -- accept or discard above"
+                                    : "dashed = interpolated · gray = unassigned · blue = flagged for review"}
                             </p>
                             {anomalyNotes.length > 0 && (
                                 <div className="mt-4 w-full">

--- a/landing-page/src/components/project/StafflineViewerModal.tsx
+++ b/landing-page/src/components/project/StafflineViewerModal.tsx
@@ -14,7 +14,10 @@ type ViewState =
 // fixed palette" visual language consistent across viewer modals.
 const PALETTE = ["#4AADAA", "#FFA500", "#E87BF7", "#F76B6B", "#6BF7A5", "#F7E16B"];
 const UNASSIGNED_COLOR = "#888888";
-const ANOMALY_COLOR = "#FF3B30";
+// Blue rather than red -- red overlay lines were getting lost against the
+// red rubrics/staff-lines common in these manuscripts (see the pages this
+// viewer is actually used on).
+const ANOMALY_COLOR = "#2563EB";
 
 interface Props {
     detection: StafflineSet;
@@ -194,7 +197,7 @@ export default function StafflineViewerModal({ detection, projectId, onClose, la
                         {detection.staveCount ?? 0} stave{detection.staveCount !== 1 ? "s" : ""}
                     </span>
                     {anomalousStaveIds.size > 0 && (
-                        <span className="text-xs font-semibold text-[#FF3B30]">
+                        <span className="text-xs font-semibold text-[#2563EB]">
                             {anomalousStaveIds.size} flagged for review
                         </span>
                     )}
@@ -273,7 +276,7 @@ export default function StafflineViewerModal({ detection, projectId, onClose, la
                                 />
                             </div>
                             <p className="mt-2 text-[#1D3335]/50 text-[11px] font-mono">
-                                dashed = interpolated · gray = unassigned · red = flagged for review
+                                dashed = interpolated · gray = unassigned · blue = flagged for review
                             </p>
                             {anomalyNotes.length > 0 && (
                                 <div className="mt-4 w-full">

--- a/landing-page/src/components/project/StafflinesTab.tsx
+++ b/landing-page/src/components/project/StafflinesTab.tsx
@@ -8,12 +8,16 @@ interface StafflinesTabProps {
   stafflines: StafflineSet[];
   images: ProjectImage[];
   projectId: number;
+  // Called when a previewed interpolation is accepted inside the viewer
+  // modal -- merges the newly persisted detection into project.stafflines.
+  onAddStaffline: (set: StafflineSet) => void;
 }
 
 export default function StafflinesTab({
   stafflines,
   images,
   projectId,
+  onAddStaffline,
 }: StafflinesTabProps) {
   const [viewSet, setViewSet] = useState<StafflineSet | null>(null);
   if (stafflines.length === 0) {
@@ -48,6 +52,13 @@ export default function StafflinesTab({
           projectId={projectId}
           onClose={() => setViewSet(null)}
           label={labelById.get(viewSet.id)}
+          onAccepted={(newSet) => {
+            onAddStaffline(newSet);
+            // Swap the modal to the just-confirmed detection so the user
+            // immediately sees the persisted (not just previewed) result,
+            // instead of it silently landing behind the still-open modal.
+            setViewSet(newSet);
+          }}
         />
       )}
       <div className="mt-6 grid grid-cols-5 gap-4">

--- a/landing-page/src/components/workflow/ProcessingPage.tsx
+++ b/landing-page/src/components/workflow/ProcessingPage.tsx
@@ -214,7 +214,20 @@ export default function ProcessingPage({
           collectedLogs.push(line);
           setRevealedLogs((prev) => [...prev, line]);
         }
-        if (ev.type === "result" && onResult) onResult(ev);
+        if (ev.type === "result" && onResult) {
+          // collectedLogs is complete for this item by the time its "result"
+          // fires -- _encode_one (tasks_encode.py) always emits its "log"
+          // events before "result", and nothing logs after "result" for that
+          // same item. For a batch job collectedLogs accumulates across ALL
+          // items processed so far (they run sequentially, each tagged with
+          // its own `[item+1/total]` prefix -- see the "log" branch above),
+          // so filter down to just this item's lines rather than attaching
+          // every earlier item's logs to each one's own add_mei call too.
+          const logs = typeof ev.item === "number"
+            ? collectedLogs.filter((l) => l.startsWith(`[${ev.item + 1}/`))
+            : [...collectedLogs];
+          onResult({ ...ev, logs });
+        }
         if (ev.type === "error") {
           setStreamError(ev.message);
           setRevealedLogs((prev) => [...prev, `error: ${ev.message}`]);

--- a/landing-page/src/hooks/useEncodingFlow.ts
+++ b/landing-page/src/hooks/useEncodingFlow.ts
@@ -31,6 +31,8 @@ export function useEncodingFlow(
     manifest: Record<string, unknown> | null;
     image_name?: string;
     stem?: string;
+    stave_source?: string | null;
+    logs?: string[];
   }) => {
     const pair = pendingBatchPairs[ev.item];
     const stem =
@@ -47,12 +49,19 @@ export function useEncodingFlow(
       xmlContent: xmlText,
       corrected: false,
       imageName,
+      staveSource: (ev.stave_source as MeiFile["staveSource"]) ?? null,
     };
     if (selectedProjectId) {
       const r = await apiFetch(`/api/projects/${selectedProjectId}/mei`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: newMeiFile.name, xmlContent: xmlText, imageName: imageName ?? null, logs: [] }),
+        body: JSON.stringify({
+          name: newMeiFile.name,
+          xmlContent: xmlText,
+          imageName: imageName ?? null,
+          logs: ev.logs ?? [],
+          staveSource: ev.stave_source ?? null,
+        }),
       });
       const saved = await r.json();
       newMeiFile.id = saved.id;
@@ -68,6 +77,8 @@ export function useEncodingFlow(
     session_id: string;
     mei_base64: string;
     manifest: Record<string, unknown> | null;
+    stave_source?: string | null;
+    logs?: string[];
   }) => {
     setNeonManifest(ev.manifest ?? null);
     const stem =
@@ -83,6 +94,7 @@ export function useEncodingFlow(
       xmlContent: xmlText,
       corrected: false,
       imageName: pendingImageFile?.name ?? undefined,
+      staveSource: (ev.stave_source as MeiFile["staveSource"]) ?? null,
     };
     if (selectedProjectId) {
       const r = await apiFetch(`/api/projects/${selectedProjectId}/mei`, {
@@ -92,7 +104,8 @@ export function useEncodingFlow(
         name: newMeiFile.name,
         xmlContent: xmlText,
         imageName: pendingImageFile?.name ?? null,
-        logs: [],
+        logs: ev.logs ?? [],
+        staveSource: ev.stave_source ?? null,
       }),
     });
     const saved = await r.json();

--- a/landing-page/src/types.ts
+++ b/landing-page/src/types.ts
@@ -83,12 +83,24 @@ export interface AnnotationSet {
   modelLabel?: string | null;
 }
 
+// Which of tasks_encode.py's 3-tier stave-source fallback produced this
+// file's zones -- see auth_api.py's mei_files migration comment for the
+// full tier list. Undefined for MEI files encoded before this was tracked.
+export type StaveSource =
+  | "staffline_detection"
+  | "yolo_annotation"
+  | "glyph_estimate"
+  | "glyph_estimate_unresolved_lines"
+  | "glyph_estimate_synthetic_lines"
+  | "placeholder_no_glyphs";
+
 export interface MeiFile {
   id: string;
   name: string;
   xmlContent?: string;
   corrected?: boolean;
   imageName?: string;
+  staveSource?: StaveSource | null;
 }
 
 export type View =


### PR DESCRIPTION
## Summary
- Fixes the anomaly-marker color (red -> blue) in `StafflineViewerModal`/`RhythmChart` -- red blended into these manuscripts' red rubrics/staff-lines.
- Adds interpolation preview/accept/discard for flagged (under-populated) staves -- `interpolate_missing` already existed as a plumbed-through parameter but was never triggered from the app.
- Persists which of `tasks_encode.py`'s 3-tier stave-source fallback produced each MEI file's zones (`mei_files.stave_source`), surfaced as a badge in `MeiViewerModal`.
- Flips the tier-3 "synthetic evenly-spaced line_ys" fallback to default OFF (opt-in only) -- previously fabricated plausible-looking but unmeasured pitch geometry by default.
- Fixes `useEncodingFlow.ts`'s `add_mei` calls, which hardcoded `logs: []` even though the backend's `project_logs` plumbing to store them already existed.
- Adds `[trace]` log lines through the whole stave-bbox pipeline (model used -> box survival counts -> JSOMR-to-StaveBbox counts -> a hard zone-coordinate parity check against the MEI actually written), so the bbox chain's integrity is directly inspectable per run.
- Backs that trace with real tests (`test_bbox_pipeline_integrity.py`): JSOMR -> `build_mei` -> zone-parity, a genuine-divergence case, and a check that the bundled stave-detector checkpoint/class-map hasn't silently drifted.

## Context
Follow-up to #154. Verified that stave bounding-box data reaching Neon is not using placeholder/default values in the normal case -- but there was no durable way to check that after the fact, and one fallback path did fabricate plausible-looking-but-invented pitch geometry by default. Both addressed here.

## Changes
- `landing-page/scripts/staffline_stage.py`: extracted `_fit_and_group()` (job-id-optional) out of `run_staffline_detection()`; added `preview_interpolation()`.
- `landing-page/scripts/inference_api.py`: new `POST .../stafflines/{id}/interpolate-preview` and `.../interpolate-confirm` routes.
- `landing-page/scripts/encode_to_mei.py`: `estimate_staves_from_glyphs()` now returns `(staves, stave_source_tag)`; new `allow_synthetic_lines` param (default `False`); new `trace_stave_zone_parity()` helper.
- `landing-page/scripts/tasks_encode.py` / `tasks_predict.py` / `tasks_text_batch.py`: tier tagging, `allow_synthetic_lines` threading, `[trace]` log lines.
- `landing-page/scripts/auth_api.py`: `mei_files.stave_source` migration.
- `landing-page/src/components/project/StafflineViewerModal.tsx`: interpolate-missing-lines button, preview/accept/discard flow, anomaly color fix.
- `landing-page/src/components/project/MeiViewerModal.tsx`: `stave_source` badge.
- `landing-page/src/hooks/useEncodingFlow.ts` / `ProcessingPage.tsx`: real log lines threaded through to `add_mei` instead of `logs: []`.

## Verification
- `tsc --noEmit` clean across the whole branch.
- `eslint` across every touched file: zero new warnings/errors vs. each file's pre-change baseline (checked via `git stash` diff per file).
- `landing-page/scripts/tests/`: 10/10 pass, including the new `test_bbox_pipeline_integrity.py`.
- Not yet run end-to-end through the live app (needs a real DB/Celery/browser session) -- worth doing before merge, especially the interpolation preview/confirm flow and the `[trace]` lines showing up in the job-log dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added staffline interpolation previews, with options to review, discard, or accept corrected results.
  * Added staffline source labels to MEI file views.
  * Added an option to allow synthetic staff lines during encoding.
  * Encoding results now retain processing logs and stave-source details.
* **Bug Fixes**
  * Improved staffline and MEI geometry validation to identify mismatches.
  * Accepted staffline corrections now appear immediately in project views.
  * Updated anomaly chart styling for clearer visual consistency.
* **Documentation**
  * Updated the README with current setup instructions, project structure, workflow details, and known gaps.
* **Tests**
  * Expanded automated coverage for landing-page workflows and MEI stave-zone integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->