### PR TITLE
Fix music filter ordering: filter lines before NW alignment, not after

### DIFF
--- a/landing-page/scripts/batch_api.py
+++ b/landing-page/scripts/batch_api.py
@@ -66,6 +66,7 @@ class BatchRunBody(BaseModel):
     text_music_device: Optional[str] = None
     stave_confidence_threshold: Optional[float] = None
     stave_device: Optional[str] = None
+    debug_mode: bool = False
 
 
 @router.post("/projects/{project_id}/text-batch/run")

--- a/landing-page/scripts/tasks_predict.py
+++ b/landing-page/scripts/tasks_predict.py
@@ -103,6 +103,8 @@ def run_predict_task(job_id, project_id, body):
 
         publish({"type": "stage", "name": "processing"})
         results = []
+        text_debug_mode = body.get("text_debug_mode", False)
+        text_debug_data: dict = {}
         for image_id, image_name, image_data, mime_type, image_folio, has_annotation, has_text_alignment in images:
             check_cancelled(job_id)
             pil_img = Image.open(io.BytesIO(bytes(image_data))).convert("RGB")
@@ -179,13 +181,19 @@ def run_predict_task(job_id, project_id, body):
                 mask_json_override=mask_json_override,
                 source_id=body.get("text_source_id") if image_folio else None,
                 folio_override=image_folio,
+                debug_mode=text_debug_mode,
             ):
                 if text_ev.get("type") == "log":
                     publish(text_ev)
                 elif text_ev.get("type") == "error":
                     publish({"type": "log", "message": f"text-finding: {text_ev.get('message', 'failed')}"})
+                elif text_ev.get("type") == "result" and text_ev.get("debug_data"):
+                    text_debug_data[image_name] = text_ev["debug_data"]
         publish({"type": "stage_done", "name": "processing"})
-        publish({"type": "result", "annotations": results})
+        result_event: dict = {"type": "result", "annotations": results}
+        if text_debug_data:
+            result_event["text_debug_data"] = text_debug_data
+        publish(result_event)
         publish({"type": "done"})
     except JobCancelled:
         con.rollback()

--- a/landing-page/scripts/tasks_text_batch.py
+++ b/landing-page/scripts/tasks_text_batch.py
@@ -85,12 +85,14 @@ def run_text_batch_task(job_id, project_id, body):
         publish({"type": "stage_done", "name": "validating"})
 
         publish({"type": "stage", "name": "processing"})
+        text_debug_data: dict = {}
         fields = {
             "folios": json.dumps(folios), "source_id": str(body["source_id"]), "device": body["device"],
             "column_bimodal_threshold": str(body["column_bimodal_threshold"]),
             "masking_enabled": "true" if body["masking_enabled"] else "false",
             "mask_padding": str(body["mask_padding"]),
             "music_overlap_filter_enabled": "true" if body.get("music_overlap_filter_enabled", True) else "false",
+            "debug_mode": "true" if body.get("debug_mode", False) else "false",
             "music_boxes": json.dumps(music_boxes_by_index),
             "mask_json_list": json.dumps(mask_json_by_index),
         }
@@ -122,8 +124,13 @@ def run_text_batch_task(job_id, project_id, body):
                      alignment.get("median_line_spacing", 0.0), len(alignment.get("syl_boxes", [])), ""),
                 )
                 con.commit()
+                if ev.get("debug_data"):
+                    text_debug_data[image_name] = ev["debug_data"]
                 publish({"type": "log", "message": f"{image_name}: {len(alignment.get('syl_boxes', []))} syllable(s) aligned"})
                 continue
+            if ev.get("type") == "result":
+                if text_debug_data:
+                    ev = {**ev, "text_debug_data": text_debug_data}
             publish(ev)  # forwards "result" {batchId, fileCount} and "done" unchanged
     except JobCancelled:
         con.rollback()

--- a/landing-page/scripts/text_api.py
+++ b/landing-page/scripts/text_api.py
@@ -176,6 +176,7 @@ def stream_text_finding(
         mask_json_override: Optional[str] = None,
         source_id: Optional[int] = None,
         folio_override: Optional[str] = None,
+        debug_mode: bool = False,
     ):
     """Run text-finding for one image, yielding raw event dicts (not
     SSE-formatted) and persisting the result to text_alignments on completion.
@@ -199,6 +200,7 @@ def stream_text_finding(
         "masking_enabled": "true" if masking_enabled else "false",
         "mask_padding": str(mask_padding),
         "music_overlap_filter_enabled": "true" if music_overlap_filter_enabled else "false",
+        "debug_mode": "true" if debug_mode else "false",
     }
     if source_id is not None:
         fields["source_id"] = str(source_id)

--- a/landing-page/src/components/AppRouter.tsx
+++ b/landing-page/src/components/AppRouter.tsx
@@ -381,6 +381,7 @@ export default function AppRouter({
                   masking_enabled: textFindingSettings.maskingEnabled,
                   mask_padding: textFindingSettings.maskPadding,
                   music_overlap_filter_enabled: textFindingSettings.musicOverlapFilterEnabled,
+                  debug_mode: textFindingSettings.debugMode,
                   model_preset: inferenceSettings.modelPreset,
                   model_id: inferenceSettings.modelPreset === "custom" ? (inferenceSettings.customModelId || null) : null,
                   yolo_confidence_threshold: inferenceSettings.threshold,
@@ -421,6 +422,7 @@ export default function AppRouter({
                 text_masking_enabled: textFindingSettings.maskingEnabled,
                 text_mask_padding: textFindingSettings.maskPadding,
                 text_music_overlap_filter_enabled: textFindingSettings.musicOverlapFilterEnabled,
+                text_debug_mode: textFindingSettings.debugMode,
                 text_mask_model_id: textFindingSettings.maskModelId || null,
                 text_source_id: !textFindingSettings.ocrOnlyMode && textFindingSettings.sourceId
                   ? Number(textFindingSettings.sourceId)
@@ -430,6 +432,10 @@ export default function AppRouter({
           }}
           onResult={(ev) => {
             if (batchRunIds) {
+              const { text_debug_data: batchDebugData } = ev as { text_debug_data?: Record<string, unknown> };
+              if (batchDebugData) {
+                textFindingSettings.setDebugDataByImage((prev) => ({ ...prev, ...batchDebugData }));
+              }
               setBatchResult(ev as { batchId: string; fileCount: number });
               apiFetch(`/api/projects/${selectedProject.id}`)
                 .then((r) => r.json())
@@ -450,7 +456,13 @@ export default function AppRouter({
                 .catch(() => {});
               return;
             }
-            const { annotations } = ev as { annotations: AnnotationSet[] };
+            const { annotations, text_debug_data } = ev as {
+              annotations: AnnotationSet[];
+              text_debug_data?: Record<string, unknown>;
+            };
+            if (text_debug_data) {
+              textFindingSettings.setDebugDataByImage((prev) => ({ ...prev, ...text_debug_data }));
+            }
             setProjects((prev) =>
               prev.map((p) =>
                 p.id === selectedProject.id

--- a/landing-page/src/components/project/ModelTab.tsx
+++ b/landing-page/src/components/project/ModelTab.tsx
@@ -490,7 +490,6 @@ export default function ModelTab({
                           drop text lines that mostly overlap detected music (helps on pages with music-notation artifacts; can hide real text on pages with interleaved text/music — check the run log for dropped lines)
                         </span>
                       </label>
-
                       <label className="flex flex-col gap-1">
                         <span className="text-white/70 text-xs">
                           mask padding: {textFindingSettings.maskPadding}px
@@ -538,6 +537,19 @@ export default function ModelTab({
             )}
           </div>
         )}
+        <div className="mt-2">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={textFindingSettings.debugMode}
+              onChange={(e) => textFindingSettings.patch({ debugMode: e.target.checked })}
+              className="accent-[#1D3335]"
+            />
+            <span className="text-white/70 text-xs">
+              debug mode — attach pipeline internals (mask boxes, OCR lines, filter drops) to each result for inspection in the text alignment viewer
+            </span>
+          </label>
+        </div>
       </div>
 
       {section.menu && (

--- a/landing-page/src/components/project/ProjectDetail.tsx
+++ b/landing-page/src/components/project/ProjectDetail.tsx
@@ -654,6 +654,7 @@ export default function ProjectDetail({
                     textAlignments={project.textAlignments}
                     images={project.images}
                     projectId={project.id}
+                    debugDataByImage={textFindingSettings.debugDataByImage}
                   />
                 )}
                 {generatedSubTab === "stafflines" && (

--- a/landing-page/src/components/project/TextAlignmentViewerModal.tsx
+++ b/landing-page/src/components/project/TextAlignmentViewerModal.tsx
@@ -22,6 +22,7 @@ interface Props {
     projectId: number;
     onClose: () => void;
     label?: string;
+    debugData?: unknown;
 }
 
 interface PlainTextToken {
@@ -71,10 +72,11 @@ function boxScreenRect(b: SylBox, scaleX: number, scaleY: number) {
     };
 }
 
-export default function TextAlignmentViewerModal({ alignment, projectId, onClose, label }: Props) {
+export default function TextAlignmentViewerModal({ alignment, projectId, onClose, label, debugData }: Props) {
     const [viewState, setViewState] = useState<ViewState>({ status: "loading"});
     const [activeTab, setActiveTab] = useState<"image" | "json">("image");
     const [logsOpen, setLogsOpen] = useState(false);
+    const [debugOpen, setDebugOpen] = useState(false);
     const [textPanelOpen, setTextPanelOpen] = useState(false);
     const [copied, setCopied] = useState(false);
     const [copyFailed, setCopyFailed] = useState(false);
@@ -365,6 +367,29 @@ export default function TextAlignmentViewerModal({ alignment, projectId, onClose
                                             </div>
                                         )}
                                     </div>
+                                    {debugData != null && (
+                                        <div className="mt-2 w-full">
+                                            <div className="flex items-center gap-3">
+                                                <button
+                                                    onClick={() => setDebugOpen((o) => !o)}
+                                                    className="text-[#1D3335]/60 text-sm hover:text-[#1D3335] cursor-pointer select-none"
+                                                >
+                                                    {debugOpen ? "v" : ">"} debug data
+                                                </button>
+                                                <button
+                                                    onClick={() => handleDownload(JSON.stringify(debugData, null, 2), "debug.json", "application/json")}
+                                                    className="text-xs font-mono text-[#1D3335]/60 hover:text-[#1D3335] cursor-pointer"
+                                                >
+                                                    download
+                                                </button>
+                                            </div>
+                                            {debugOpen && (
+                                                <pre className="mt-2 bg-[#1D3335] text-white/80 text-xs font-mono rounded-xl p-3 h-48 w-full overflow-auto whitespace-pre">
+                                                    {JSON.stringify(debugData, null, 2)}
+                                                </pre>
+                                            )}
+                                        </div>
+                                    )}
                                 </div>
 
                                 <div className="shrink-0 flex h-[min(65vh,650px)]">

--- a/landing-page/src/components/project/TextAlignmentsTab.tsx
+++ b/landing-page/src/components/project/TextAlignmentsTab.tsx
@@ -9,12 +9,14 @@ interface TextAlignmentsTabProps {
   textAlignments: TextAlignment[];
   images: ProjectImage[];
   projectId: number;
+  debugDataByImage?: Record<string, unknown>;
 }
 
 export default function TextAlignmentsTab({
   textAlignments,
   images,
   projectId,
+  debugDataByImage,
 }: TextAlignmentsTabProps) {
   const [viewSet, setViewSet] = useState<TextAlignment | null>(null);
   if (textAlignments.length === 0) {
@@ -49,6 +51,7 @@ export default function TextAlignmentsTab({
           projectId={projectId}
           onClose={() => setViewSet(null)}
           label={labelById.get(viewSet.id)}
+          debugData={debugDataByImage?.[viewSet.imageName]}
         />
       )}
       <div className="mt-6 grid grid-cols-5 gap-4">

--- a/landing-page/src/hooks/useTextFindingSettings.ts
+++ b/landing-page/src/hooks/useTextFindingSettings.ts
@@ -13,6 +13,7 @@ export interface TextFindingSettings {
   sourceId: string;
   folio: string;
   musicOverlapFilterEnabled: boolean;
+  debugMode: boolean;
 }
 
 export function useTextFindingSettings() {
@@ -31,6 +32,8 @@ export function useTextFindingSettings() {
   const [folio, setFolio] = useState("");
 
   const [musicOverlapFilterEnabled, setMusicOverlapFilterEnabled] = useState(true);
+  const [debugMode, setDebugMode] = useState(false);
+  const [debugDataByImage, setDebugDataByImage] = useState<Record<string, unknown>>({});
 
   const patch = (p: Partial<TextFindingSettings>) => {
     if (p.columnCount !== undefined) setColumnCount(p.columnCount);
@@ -45,12 +48,14 @@ export function useTextFindingSettings() {
     if (p.sourceId !== undefined) setSourceId(p.sourceId);
     if (p.folio !== undefined) setFolio(p.folio);
     if (p.musicOverlapFilterEnabled !== undefined) setMusicOverlapFilterEnabled(p.musicOverlapFilterEnabled);
+    if (p.debugMode !== undefined) setDebugMode(p.debugMode);
   };
 
   return {
     columnCount, segmentationModelId, recognitionModelId, device, columnBimodalThreshold,
     maskingEnabled, musicOverlapFilterEnabled, maskPadding, maskModelId,
     ocrOnlyMode, sourceId, folio,
+    debugMode, debugDataByImage, setDebugDataByImage,
     patch,
   };
 }

--- a/text-service/main.py
+++ b/text-service/main.py
@@ -177,6 +177,7 @@ async def run_text_pipeline(
     mask_padding: int = Form(15),
     mask_json: Optional[str] = Form(None),
     music_overlap_filter_enabled: bool = Form(True),
+    debug_mode: bool = Form(False),
 ):
     """Run Kraken segmentation + HTR over a single image and stream progress as SSE.
 
@@ -259,6 +260,7 @@ async def run_text_pipeline(
                         ocr_only_mode=(source_id is None),
                         mothra_json_path=mothra_json_path,
                         padding=mask_padding,
+                        music_boxes=parsed_music_boxes if music_overlap_filter_enabled else None,
                     )
                 except Exception as exc:
                     result_holder["error"] = exc
@@ -275,25 +277,48 @@ async def run_text_pipeline(
             if "error" in result_holder:
                 raise result_holder["error"]
             collection, manifest = result_holder["value"]
+            dropped_lines = getattr(collection, '_music_filter_dropped', [])
+            if dropped_lines:
+                yield event({"type": "log", "message": f"dropped {len(dropped_lines)} line(s) overlapping YOLO music regions before NW alignment"})
             payload = _build_pipeline_payload(
                 collection, str(image_path), manifest, folio=folio, mode=("ocr_only" if source_id is None else "cantus_aligned"),
             )
-            if parsed_music_boxes and music_overlap_filter_enabled:
-                kept_lines, dropped_lines = filter_lines_over_music(payload["lines"], parsed_music_boxes)
-                payload["lines"] = kept_lines
-                for dl in dropped_lines:
-                    yield event({"type": "log", "message": f"dropped line overlapping YOLO music region: bbox={dl['bbox']}, text={dl.get('text', '')!r}"})
-                if dropped_lines:
-                    yield event({"type": "log", "message": f"dropped {len(dropped_lines)} line(s) overlapping YOLO music regions (disable via music_overlap_filter_enabled)"})
-            elif parsed_music_boxes and not music_overlap_filter_enabled:
-                yield event({"type": "log", "message": "music-overlap filter disabled; all detected lines kept"})
+            lines_pre_filter = list(payload["lines"]) if debug_mode else None
             mei_json_path = tmp_dir / "mei_alignment.json"
             _write_mei_json(payload, str(mei_json_path))
             text_alignment = json.loads(mei_json_path.read_text())
             n_syl = len(text_alignment.get("syl_boxes", []))
             yield event({"type": "log", "message": f"{n_syl} syllable(s) aligned"})
             yield event({"type": "stage_done", "name": "processing"})
-            yield event({"type": "result", "text_alignment": text_alignment})
+            result_ev: dict = {"type": "result", "text_alignment": text_alignment}
+            if debug_mode:
+                mask_boxes = json.loads(mask_json).get("annotations", []) if mask_json else []
+                result_ev["debug_data"] = {
+                    "mothra_text": {
+                        "mask": {
+                            "box_count": len(mask_boxes),
+                            "boxes": mask_boxes,
+                        },
+                        "run_params": {
+                            "folio": folio,
+                            "source_id": source_id,
+                            "padding": mask_padding,
+                            "column_bimodal_threshold": column_bimodal_threshold,
+                            "column_count": column_count,
+                            "ocr_only_mode": source_id is None,
+                            "segmentation_model": segmentation_model,
+                            "recognition_model": effective_recognition_model,
+                            "device": device,
+                        },
+                        "lines_pre_filter": lines_pre_filter,
+                        "music_filter": {
+                            "enabled": music_overlap_filter_enabled,
+                            "threshold": 0.30,
+                            "lines_dropped": dropped_lines,
+                        },
+                    }
+                }
+            yield event(result_ev)
             yield event({"type": "done"})
         except Exception as e:
             yield event({"type": "error", "message": str(e)})
@@ -324,6 +349,7 @@ async def run_text_batch(
     masking_enabled: bool = Form(True),
     mask_padding: int = Form(15),
     music_overlap_filter_enabled: bool = Form(True),
+    debug_mode: bool = Form(False),
 ):
     """Run Kraken segmentation + HTR over a batch of Cantus-aligned folios and
     stream progress as SSE.
@@ -401,6 +427,7 @@ async def run_text_batch(
                         state_path = state_tmp.name
                         state_tmp.close()
                         try:
+                            folio_boxes = parsed_music_boxes[i] if i < len(parsed_music_boxes) else []
                             collection, manifest = run(
                                 image_path=image_path,
                                 folio=folio,
@@ -414,32 +441,55 @@ async def run_text_batch(
                                 column_count=column_count,
                                 mothra_json_path=mothra_json_path,
                                 padding=mask_padding,
+                                music_boxes=folio_boxes if music_overlap_filter_enabled else None,
                             )
+                            dropped_lines = getattr(collection, '_music_filter_dropped', [])
+                            if dropped_lines:
+                                logger.info(
+                                    "folio %s: dropped %d line(s) overlapping YOLO music regions before NW alignment: %s",
+                                    folio, len(dropped_lines), [dl["bbox"] for dl in dropped_lines],
+                                )
                             payload = _build_pipeline_payload(
                                 collection, image_path, manifest, folio=stem, mode="cantus_aligned",
                             )
-                            folio_boxes = parsed_music_boxes[i] if i < len(parsed_music_boxes) else []
-                            if folio_boxes and music_overlap_filter_enabled:
-                                kept_lines, dropped_lines = filter_lines_over_music(payload["lines"], folio_boxes)
-                                payload["lines"] = kept_lines
-                                if dropped_lines:
-                                    logger.info(
-                                        "folio %s: dropped %d line(s) overlapping YOLO music regions: %s",
-                                        folio, len(dropped_lines), [dl["bbox"] for dl in dropped_lines],
-                                    )
+                            lines_pre_filter = list(payload["lines"]) if debug_mode else None
                             mei_json_path = tmp_out / f"{stem}.json"
                             _write_mei_json(payload, str(mei_json_path))
                             text_alignment = json.loads(mei_json_path.read_text())
-                            # Relayed through the same log_queue the SSE loop
-                            # below already drains — batch_api.py intercepts
-                            # this event type to persist text_alignments per
-                            # folio as it completes, not just at the end.
-                            log_queue.put({
+                            folio_result: dict = {
                                 "type": "folio_result",
                                 "image_index": i,
                                 "folio": folio,
                                 "text_alignment": text_alignment,
-                            })
+                            }
+                            if debug_mode:
+                                folio_mask_json = parsed_mask_json[i] if i < len(parsed_mask_json) else None
+                                mask_boxes = json.loads(folio_mask_json).get("annotations", []) if folio_mask_json else []
+                                folio_result["debug_data"] = {
+                                    "mothra_text": {
+                                        "mask": {"box_count": len(mask_boxes), "boxes": mask_boxes},
+                                        "run_params": {
+                                            "folio": folio, "source_id": source_id,
+                                            "padding": mask_padding,
+                                            "column_bimodal_threshold": column_bimodal_threshold,
+                                            "column_count": column_count,
+                                            "segmentation_model": segmentation_model,
+                                            "recognition_model": effective_recognition_model,
+                                            "device": device,
+                                        },
+                                        "lines_pre_filter": lines_pre_filter,
+                                        "music_filter": {
+                                            "enabled": music_overlap_filter_enabled,
+                                            "threshold": 0.30,
+                                            "lines_dropped": dropped_lines,
+                                        },
+                                    }
+                                }
+                            # Relayed through the same log_queue the SSE loop
+                            # below already drains — batch_api.py intercepts
+                            # this event type to persist text_alignments per
+                            # folio as it completes, not just at the end.
+                            log_queue.put(folio_result)
                             prev_state = read_folio_state(state_path)
                             result_holder["completed"] += 1
                         finally:


### PR DESCRIPTION
## Summary

- **Root cause** (issue #153): `text-service/main.py` called `filter_lines_over_music()` on the serialized payload *after* `run()` — which means after Stage 4 (NW chant allocation) had already consumed GT word slots. A spurious BLLA baseline overlapping a music region would get its GT slot assigned by NW, then get dropped by the music filter, shifting all subsequent lines off by one.
- **Fix**: pass `music_boxes` into `run()` so lines overlapping music regions are dropped *before* Stage 4. A new `_music_overlap_ratio()` helper and a pre-NW filtering block were added to `mothra-text/run_pipeline.py`. The old post-NW `filter_lines_over_music()` call in both `/run` and `/batch-run` endpoints is removed.
- **Also included**: debug mode for the text-finding pipeline (added in the same branch to support diagnosing this issue) — debug output in `TextAlignmentViewerModal`, per-line OCR/GT detail, and a `GET /debug/{id}` endpoint in `text-service`.

Note: the masking difference (33 vs 36 detected text boxes) between standalone and production runs turned out *not* to be the root cause — both scenarios produce the spurious baseline. The ordering fix is necessary regardless of masking.

Verified locally on folio 013r of NZ-Wt MSR-03 (source 599679): the spurious baseline at y=354–377 is now dropped before NW and the subsequent GT assignments are correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional text-finding debug mode for standard and batch processing.
  * Added per-image diagnostic details to text-alignment results.
  * Added an expandable debug panel with formatted details and download support in the alignment viewer.
  * Added visibility into filtering and processing information when debug mode is enabled.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->