### PR TITLE
Type-check the frontend in CI and harden workflows against Actions outages

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -21,6 +21,10 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # A cold (cache-miss) backend build runs ~5-10 min. Anything past 45 is a
+    # stuck runner or a hung registry pull, not a slow build -- release the
+    # runner instead of letting it sit for the 6h default.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -104,6 +108,9 @@ jobs:
     # images are guaranteed to exist before we roll the deployments.
     needs: build
     runs-on: ubuntu-latest
+    # Bounds the job as a whole; the rollout loop below already caps itself at
+    # 300s per deployment (4 deployments = 20 min worst case).
+    timeout-minutes: 30
     # Serialize deploys per branch; don't cancel an in-flight rollout.
     concurrency:
       group: deploy-${{ github.ref }}

--- a/.github/workflows/rerun-on-infra-failure.yml
+++ b/.github/workflows/rerun-on-infra-failure.yml
@@ -1,0 +1,92 @@
+name: rerun-on-infra-failure
+
+# Automatically re-runs a failed `tests`/`ci-cd` run when the failure was
+# GitHub's fault rather than ours.
+#
+# Why this exists: on 2026-08-06 a critical GitHub Actions incident
+# (githubstatus.com, 15:22Z -> 2026-08-07 02:05Z) made jobs fail before a
+# single step from our workflow file ever ran, with:
+#
+#     Getting action download info
+#     Failed to resolve action download info. Error: Service Unavailable
+#     ##[error]Service Unavailable
+#
+# The runner retries that resolution twice internally (~20-30s apart) and then
+# gives up. Because it happens during "Set up job", *no* in-workflow mechanism
+# can catch it -- not `continue-on-error`, not a retry action, not a step-level
+# `if:`. None of our steps exist yet. Re-running the run is the only recourse,
+# so this automates that instead of relying on someone noticing the red X.
+#
+# It is deliberately narrow. An infrastructure failure never gets past setup:
+# the failed job either records no steps at all (job cancelled while queued) or
+# its only failing step is "Set up job" itself. A genuine test or build failure
+# always fails at a named step from the workflow file, so it is left alone and
+# stays red -- this cannot paper over a real break.
+#
+# Caveat: during a severe incident, webhook delivery is itself throttled (on
+# 2026-08-06 GitHub was processing ~15% of webhooks at the low point), so this
+# workflow may not fire at all. It shortens the recovery tail; it is not a
+# guarantee. Re-run by hand with `gh run rerun <id> --failed` when needed.
+
+on:
+  workflow_run:
+    workflows: ["tests", "ci-cd"]
+    types: [completed]
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  rerun:
+    # run_attempt caps the retries: attempt 1 and 2 may be re-run, so a run
+    # gets at most 3 total attempts before it is left red for a human.
+    if: >
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.run_attempt < 3
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # Note: no `actions/checkout`, no `setup-*`, nothing from the Actions
+      # marketplace -- only `gh`, which is preinstalled on the runner image.
+      # That is intentional: a job with zero actions to resolve has nothing to
+      # fail at the "Getting action download info" step this workflow exists to
+      # recover from.
+      - name: Re-run only if the failure happened before any step ran
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+        run: |
+          set -euo pipefail
+
+          # One line per bad job: a JSON array of that job's failing step names.
+          gh api "repos/$REPO/actions/runs/$RUN_ID/jobs?per_page=100" --paginate \
+            --jq '.jobs[]
+                  | select(.conclusion == "failure" or .conclusion == "cancelled")
+                  | [ .steps[]? | select(.conclusion == "failure") | .name ]
+                  | @json' > failing_steps.txt
+
+          if [ ! -s failing_steps.txt ]; then
+            echo "Run $RUN_ID reported failure but no failed/cancelled job was found; not re-running."
+            exit 0
+          fi
+
+          echo "Failing steps per bad job in run $RUN_ID (attempt $ATTEMPT):"
+          cat failing_steps.txt
+
+          while read -r steps; do
+            case "$steps" in
+              # []              -> job never started; cancelled while queued.
+              # ["Set up job"]  -> died resolving actions / provisioning.
+              '[]'|'["Set up job"]') ;;
+              *)
+                echo "Real failure at $steps -- leaving run $RUN_ID red."
+                exit 0
+                ;;
+            esac
+          done < failing_steps.txt
+
+          echo "All failures are setup-level (GitHub-side). Re-running failed jobs."
+          gh run rerun "$RUN_ID" --failed

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,9 +14,20 @@ on:
   push:
   workflow_dispatch:
 
+# Only the newest push per branch needs testing. Superseded runs are cancelled
+# rather than left to queue -- during the 2026-08-06 Actions incident, branches
+# with rapid successive pushes had several redundant runs each competing for
+# scarce hosted runners, which made the backlog worse for everyone.
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    # The whole suite finishes in ~2 min. A job sitting far past that is stuck
+    # on infrastructure, not working -- fail fast instead of holding a runner.
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -62,3 +73,43 @@ jobs:
 
       - name: landing-page -- staffline_adapter tests
         run: python -m pytest landing-page/scripts/tests/test_staffline_adapter.py
+
+  # Type-checks the landing-page frontend on every branch push. Before this
+  # job existed, nothing compiled TypeScript until `npm run build` ran inside
+  # landing-page/Dockerfile -- which only happens in the ci-cd workflow, which
+  # only runs on main. So a type error was invisible until *after* it had been
+  # merged, and it surfaced as a failed deploy rather than a failed test. That
+  # is exactly how `error TS6133: 'StafflinesTab' is declared but its value is
+  # never read` broke the ci-cd builds for two consecutive merges to main on
+  # 2026-08-04 (runs 30931964838 and 30940199845).
+  #
+  # This runs `tsc -b` only -- not the full `npm run build`. tsconfig.app.json
+  # sets "noEmit": true and includes just `src`, so `tsc -b` is a pure
+  # type-check that needs neither the neon submodule nor `build:neon`'s yarn
+  # step. It catches the same errors in ~5s that the Docker build takes ~5min
+  # to reach.
+  #
+  # `npm run lint` is deliberately NOT run here: eslint currently reports ~197
+  # pre-existing errors across the codebase, so adding it would fail every run
+  # until that backlog is cleared. Worth adding once it is green.
+  frontend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: landing-page/package-lock.json
+
+      - name: Install dependencies
+        working-directory: landing-page
+        run: npm ci
+
+      - name: Type-check (tsc -b)
+        working-directory: landing-page
+        run: npx tsc -b


### PR DESCRIPTION
Three CI changes, all confined to `.github/workflows/`. No application code is touched.

### Type-check the frontend on every push

`tests.yml` gains a `frontend` job. Until now nothing compiled the frontend's TypeScript before merge — that only happened inside `landing-page/Dockerfile` during `ci-cd`, which runs on `main` only. So a type error was invisible until *after* it had been merged, and surfaced as a failed deploy rather than a failed test. That is exactly how `error TS6133: 'StafflinesTab' is declared but its value is never read` broke the `ci-cd` build for two consecutive merges to `main` on 2026-08-04 (runs 30931964838 and 30940199845).

The job runs `npx tsc -b` only, not the full `npm run build`. `tsconfig.app.json` sets `"noEmit": true` and includes just `src`, so this is a pure type-check that needs neither the `neon` submodule nor `build:neon`'s yarn step — it catches the same errors in ~5s that the Docker build takes ~5min to reach.

`npm run lint` is deliberately left out: eslint currently reports ~197 pre-existing errors across the codebase, so adding it would fail every run until that backlog is cleared. Worth adding once it's green.

### Auto-rerun runs that failed before they started

New workflow, `rerun-on-infra-failure.yml`. During the 2026-08-06 Actions incident, jobs failed at "Set up job" with `Failed to resolve action download info. Error: Service Unavailable` — before a single step from our workflow file ever ran. Nothing in-workflow can catch that: not `continue-on-error`, not a retry action, not a step-level `if:`, because none of our steps exist yet. Re-running is the only recourse, so this automates it instead of relying on someone noticing the red X.

It is deliberately narrow. It re-runs only when *every* failing job either recorded no steps at all (cancelled while queued) or failed solely at "Set up job". A failure at any named step from the workflow file is left alone and stays red, so this cannot paper over a real break. `run_attempt < 3` caps a run at three attempts before it's left for a human.

The job uses no marketplace actions at all — only the preinstalled `gh` — so it has nothing to resolve at the very step it exists to recover from.

### Concurrency and timeouts

`tests.yml` gets a per-branch concurrency group with `cancel-in-progress`, so rapid successive pushes don't leave several redundant runs each competing for scarce hosted runners. Every job across both workflows gets a `timeout-minutes` (20 tests, 15 frontend, 45 build, 30 deploy), so a run stuck on infrastructure releases its runner instead of holding it for the 6h default.

### Notes for the reviewer

`workflow_run` triggers always run the version of the workflow that's on the default branch, so `rerun-on-infra-failure.yml` does nothing until this is merged — it can't be exercised from this branch. The `frontend` job and the concurrency/timeout changes do take effect here and can be checked against this PR's own run.

One caveat on the rerun workflow, also recorded in a comment in the file: during a severe incident webhook delivery is itself throttled (GitHub was processing ~15% of webhooks at the low point on 2026-08-06), so it may not fire at all. It shortens the recovery tail; it is not a guarantee. `gh run rerun <id> --failed` by hand remains the fallback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added dedicated validation for landing-page TypeScript changes.
  - Improved test run management by cancelling superseded runs and applying practical time limits.
  - Added automatic retries for infrastructure-related failures, while leaving genuine test and build failures unchanged.

- **Chores**
  - Added time limits to image build and deployment processes to prevent stalled operations and improve delivery reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->