### PR TITLE
Fail clearly when ultralytics is unavailable; make IC training presets exclusive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,10 @@ landing-page/scripts/.venv
 # local environment variables (contain secrets — never commit)
 .env
 landing-page/scripts/.env
+# Vite's local overrides. The `.env` pattern above does not match these — the
+# filename differs — so they need their own entry.
+.env.local
+.env.*.local
 text-service/.venv
 
 # artifacts from component filtering

--- a/landing-page/scripts/inference_api.py
+++ b/landing-page/scripts/inference_api.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 import uuid as _uuid
 
 from auth_api import get_current_user, require_project_owner, db_cursor
+from config import SKIP_YOLO
 from job_store import create_job
 from tasks_predict import run_predict_task
 
@@ -39,6 +40,20 @@ async def run_predict(
     with db_cursor() as (con, cur):
         require_project_owner(cur, project_id, user["id"])
 
+    # MOTHRA_SKIP_YOLO means this box can't run ultralytics, so refuse here
+    # rather than enqueueing a job that can only die in the worker — the caller
+    # gets a reason instead of a failed row. Only covers this endpoint; a retry
+    # of an older job replays params straight to the task, which is why
+    # resolve_yolo_models() carries its own guard.
+    if SKIP_YOLO:
+        raise HTTPException(
+            status_code=503,
+            detail="YOLO inference is disabled on this server (MOTHRA_SKIP_YOLO is "
+                   "set, normally because ultralytics isn't installed). Set "
+                   "VITE_SKIP_PREDICT=1 in landing-page/.env.local so the UI skips "
+                   "this step, or unset MOTHRA_SKIP_YOLO once ultralytics is "
+                   "installed.",
+        )
     if body.model_preset == "printed":
         raise HTTPException(status_code=400, detail="printed text detection is not available yet!")
     if body.model_preset == "custom" and not body.model_id: 

--- a/landing-page/scripts/yolo_inference.py
+++ b/landing-page/scripts/yolo_inference.py
@@ -90,7 +90,21 @@ def resolve_yolo_models(
     Raises RuntimeError (medieval preset unavailable) or ValueError (custom
     model not found) - callers decide how to surface that as an SSE error.
     """
-    from ultralytics import YOLO
+    # Raised as RuntimeError, not left as the bare ModuleNotFoundError: callers
+    # (tasks_predict, batch_api) catch RuntimeError/ValueError and surface the
+    # text as an SSE error, whereas an ImportError escapes those handlers and
+    # kills the job with an opaque traceback instead of an actionable message.
+    try:
+        from ultralytics import YOLO
+    except ImportError as exc:
+        raise RuntimeError(
+            "YOLO inference needs the 'ultralytics' package, which isn't installed "
+            "in this environment. Either install it "
+            "(pip install -r landing-page/scripts/requirements.txt), or skip the "
+            "predict step: set MOTHRA_SKIP_YOLO=1 in landing-page/scripts/.env and "
+            "VITE_SKIP_PREDICT=1 in landing-page/.env.local, then restart the "
+            "backend, the Celery worker, and the Vite dev server."
+        ) from exc
 
     tm_threshold = text_music_confidence_threshold if text_music_confidence_threshold is not None else confidence_threshold
     st_threshold = stave_confidence_threshold if stave_confidence_threshold is not None else confidence_threshold

--- a/landing-page/src/components/AppRouter.tsx
+++ b/landing-page/src/components/AppRouter.tsx
@@ -28,7 +28,14 @@ const STEP_TIMING = { intervalMs: 60, completionDelayMs: 4000 } as const;
 // straight to the Interactive Classifier (which falls back to placeholder
 // bboxes server-side when no YOLO annotations exist). Pair with MOTHRA_SKIP_YOLO
 // on the backend so model uploads skip checkpoint inspection too.
-const SKIP_PREDICT = Boolean(import.meta.env.VITE_SKIP_PREDICT);
+// Parsed the same way as the backend's MOTHRA_SKIP_YOLO rather than with a bare
+// Boolean(), which treats *any* non-empty string as true — including the
+// "VITE_SKIP_PREDICT=0" someone writes to turn the bypass back off.
+const SKIP_PREDICT = ["1", "true", "yes"].includes(
+  String(import.meta.env.VITE_SKIP_PREDICT ?? "")
+    .trim()
+    .toLowerCase(),
+);
 
 // A project's used images are eligible for the batch (cross-folio-aware)
 // text-finding pipeline only when every one of them was tagged with a folio

--- a/landing-page/src/components/workflow/InteractiveClassifier.tsx
+++ b/landing-page/src/components/workflow/InteractiveClassifier.tsx
@@ -167,10 +167,13 @@ export default function InteractiveClassifier({
       .catch(() => setAvailablePresets([]));
   }, []);
 
+  // Presets are mutually exclusive here for the same reason they are in the
+  // IC iframe's own picker: checking one unchecks the rest. Kept as an array
+  // because the batch prefill and the API both take a list, and an uploaded
+  // set can still be combined with a preset — only preset-vs-preset is
+  // exclusive.
   const togglePreset = (name: string, checked: boolean) => {
-    setTrainingPresets((prev) =>
-      checked ? [...prev, name] : prev.filter((n) => n !== name),
-    );
+    setTrainingPresets(checked ? [name] : []);
     reloadOpenCreateSession();
   };
 


### PR DESCRIPTION
Two small fixes: making the "this machine can't run YOLO" path fail with an actionable message instead of a dead job, and the IC preset-exclusivity fix that goes with the `ic` submodule bump.

## Skipping YOLO where ultralytics isn't installed

`POST /projects/{id}/predict` now returns 503 with an explanation when `MOTHRA_SKIP_YOLO` is set, rather than enqueueing a job that can only die in the worker. `resolve_yolo_models()` keeps its own guard because job retry replays stored params straight to the task and never passes through that endpoint — it converts the bare `ModuleNotFoundError` into a `RuntimeError`, which the existing `RuntimeError`/`ValueError` handlers in `tasks_predict.py` and `batch_api.py` already surface as an SSE error message; an `ImportError` escapes those handlers and kills the job with an opaque traceback instead.

On the frontend, `VITE_SKIP_PREDICT` is now parsed the same way as the backend's `MOTHRA_SKIP_YOLO` (`1`/`true`/`yes`). The old bare `Boolean()` treated any non-empty string as true, so `VITE_SKIP_PREDICT=0` — the obvious way to turn the bypass back off — silently kept it on.

`.gitignore` also picks up `.env.local` and `.env.*.local`, which the existing `.env` entry doesn't match.

## IC training presets

Bumps the `ic` submodule to `f2d1806`, which brings mutual exclusion for training presets and re-classification on binarization change. `InteractiveClassifier.tsx`'s own preset picker now behaves the same way: checking one preset unchecks the others. It stays an array because the batch prefill and the API both take a list, and an uploaded classifier set can still be combined with a preset — only preset-vs-preset is exclusive.
