### PR TITLE
fix: disable credential persistence in tests.yml checkout steps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -98,6 +100,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

CodeRabbit flagged a Major security finding on PR #162 for `.github/workflows/tests.yml`: `actions/checkout@v4` persists the GitHub token in local git config by default, and since the `frontend` job runs `npm ci`, dependency lifecycle scripts (e.g. `postinstall`) could read that token off disk. This adds `persist-credentials: false` to both the `test` and `frontend` jobs' checkout steps.

Split out from #162 since it is unrelated to that PR's staffline-module scope.

## Test plan
- No functional change to what the workflow runs, just prevents credentials from being written to .git/config after checkout.
- CI on this PR itself exercises both jobs' checkout steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)