### PR TITLE
fix: resolve staffline detection landing-vs-local audit + stale-annotation guard

### DIFF
--- a/documentation_allons-y/STAFFLINE_INTEGRATION_FOLLOWUPS.md
+++ b/documentation_allons-y/STAFFLINE_INTEGRATION_FOLLOWUPS.md
@@ -266,6 +266,122 @@ behavior, not just a passing compile):
   editable to normal, since the whole source tree is already baked into
   the image regardless.
 
+## Diagnosed this session (kyrie/staffline-landing-audit)
+
+Kyrie reported the same manuscript page (`Plimpton041_167v`) producing
+visibly worse staffline-detection results through mothra-landing (the
+deployed k8s instance) than through a local `staff-finding` pipeline run,
+with a direct local-vs-deployed comparison as evidence: the local run
+grouped 5 staves cleanly at mode 4 lines/stave (correct for this chant
+manuscript); the deployed run's `staffline_detections` JSOMR showed
+`lines_expected: 2` (a computed statistic — `group_staves.py`'s own
+`mode_lines_per_stave`, not a config knob) — i.e. a real quality gap, not a
+different reading of the same data.
+
+- **Root cause 1 — git version drift, not an algorithm bug.**
+  `kyrie/staff-finding` was 50 commits behind `origin/main` (what's actually
+  deployed). `git diff --stat` confirmed `staff-finding/`'s own algorithmic
+  package hadn't drifted at all — the divergence was entirely in
+  landing-page's integration layer, which had picked up several relevant
+  fixes since the last merge: `916f465` (staffline detection now also runs
+  in the text-batch path), `1b2ea4d` (interpolate preview/confirm flow),
+  `7c80858` (flips tier-3's synthetic-line fabrication to off by default,
+  tags every MEI's `stave_source`). Bundled `.pt` model weights were
+  byte-identical between local and deployed, ruling out a model-retrain
+  explanation. Branched fresh from `origin/main`
+  (`kyrie/staffline-landing-audit`) to re-diagnose on current code rather
+  than chasing an already-fixed gap.
+- **Root cause 2 — real, independent staleness bug, fixed this session.**
+  `tasks_encode.py`'s `_resolve_hints()` tier-1 query picked the newest
+  `succeeded` `staffline_detections` row by `created_at`, with no check that
+  it matched the image's *current* annotation. Since `staffline_detections`
+  accumulates forever (see the retention note above) while `annotations` is
+  delete-then-insert on re-predict, a project re-annotated/re-predicted
+  since its last staffline detection would still match on `created_at DESC`
+  and silently encode against geometrically stale stave data — exactly the
+  scenario a fresh local DB never hits, but a long-running deployed DB
+  eventually does. `inference_api.py`'s interpolate-preview/confirm routes
+  already guarded against this exact class of staleness (resolving the
+  current annotation via `image_id` before trusting a detection row); the
+  same guard was missing from `_resolve_hints` itself. Fixed: `_resolve_hints`
+  now looks up the image's current annotation first, then requires tier 1's
+  `staffline_detections` row to match that annotation's id — falling
+  through to tier 2 (using the current annotation's own `yolo_txt`) when no
+  detection matches, instead of trusting the newest timestamp alone. Test:
+  `landing-page/scripts/tests/test_resolve_hints_staleness.py` (hand-rolled
+  fake cursor + `sys.modules` stubs for `auth_api`/`job_store`/`celery_app`,
+  since importing `tasks_encode` for real would need a live Postgres/Redis —
+  same DB-at-import-time constraint `test_bbox_pipeline_integrity.py`'s own
+  docstring already documents).
+- **Live end-to-end re-verification against the actual reported page could
+  not be completed in this session** — the sandbox this diagnosis ran in
+  has neither `ic/api/.venv` nor `text-service/.venv` set up, and no Redis
+  broker reachable, so `./dev.sh`'s full 5-service stack (needed for a real
+  predict-job re-run) couldn't be started. Whoever picks this up next should
+  re-run `Plimpton041_167v` through a real `POST /projects/{id}/predict` on
+  `kyrie/staffline-landing-audit` (or `main`) and confirm the resulting
+  `staffline_detections.mode_lines_per_stave` now matches the local e2e
+  baseline (mode 4) instead of the originally-reported `lines_expected: 2`.
+  If it still doesn't match after root causes 1 and 2 above are accounted
+  for, the next suspects (in order, per this session's process of
+  elimination — model weights and `staff-finding/` code already ruled out):
+  1. Fewer/worse stave-class (YOLO class id 2) boxes in the deployed
+     project's actual `annotations.yolo_txt` for this image than the local
+     e2e fixture's `yolo_txt/Plimpton041_167v copy.txt` — check which model
+     that specific project actually uses (medieval preset vs. a custom
+     uploaded model row in `project_models`).
+  2. `landing-page/src/utils/imageResize.ts`'s client-side resize (uploads
+     over 5MB) landing the deployed project's source image at different
+     pixel dimensions than the local e2e fixture's raw file — this changes
+     `scale_unit` (median stave-box pixel height) and therefore the Sauvola
+     binarization window size and downstream fit/grouping thresholds even
+     with identical code and models.
+  3. Only if both check out clean: this may be a real instance of the
+     already-documented, unfixed `group_staves.py` dense-stave
+     reconciliation gap (see "Three checked-in e2e baselines show genuinely
+     fragmented grouping" above) rather than an integration bug — a real
+     algorithmic limitation, not a quick fix.
+
+## Watching for calvo-integration merge
+
+`gianna/calvo-integration` (not yet merged; reviewed via `gh api` this
+session, not a local checkout) is an **ink-separation front-end**, not a
+bounding-box detector in its own right — exactly the "ink-separation (BGR)"
+deferral already flagged in `staff-finding/dox/STATUS.md` and above, just
+implemented via DDMAL's own `Paco_classifier` submodule instead of the
+unvendored `muscrat/layer_sep` repo. `paco_api.py`/`paco-classifier-service`
+wrap `Paco_classifier.recognition_engine.process_image_msae()` (a TensorFlow
+pixel classifier) to split a page into background/stafflines RGBA layers;
+`tasks_predict.py`'s `_run_medieval_inference` on that branch then runs the
+*existing* stave YOLO model against the classified "stafflines" layer
+instead of the raw page crop, still producing ordinary YOLO-txt boxes at
+`STAFFLINE_CLASS_ID = 2` (confirmed unchanged: `CATEGORY_TO_SLOT["staves"] =
+2` in `yolo_inference.py` on both branches).
+
+No format-level blocker for `staff-finding/` when this merges. Two things
+worth validating at merge time rather than assuming they hold:
+- `component_filter.py`'s Sauvola binarization is tuned against raw
+  grayscale crops; once ink-separation actually lands, it'll instead see a
+  pre-segmented layer with background forced to pure white (per
+  `_layer_to_rgba_png`'s masking). Worth a validation pass against a few
+  e2e fixtures — the tuning that was an "interim mitigation for faint ink"
+  may behave differently (better or worse) against an already-cleaner
+  input than it was tuned for.
+- `run_staffline_detection` on that branch crops `staffline_source_arr` (the
+  same classified image the stave YOLO model scored), not the raw page.
+  `process_image_msae` restores full input resolution internally, so
+  `scale_unit` (median stave-box pixel height) should still resolve in the
+  correct coordinate frame — but this is a "should," not yet an assertion;
+  add an explicit test for it once this merges rather than assuming it
+  holds.
+
+Also noted for later, out of scope here: the eventual pitch-finding consumer
+of this staffline geometry is
+[DDMAL/Standalone-Pitch-Finder](https://github.com/DDMAL/Standalone-Pitch-Finder)
+(in progress, not yet integrated) — its JSOMR/stave-geometry output contract
+needs to satisfy that project too, not just today's MEI-encoding consumer
+(`staffline_adapter.py`/`encode_to_mei.py`).
+
 ## Needs a manual step, not a code change
 
 - **Branch protection**: `.github/workflows/tests.yml` runs on every push,

--- a/landing-page/scripts/tasks_encode.py
+++ b/landing-page/scripts/tasks_encode.py
@@ -52,6 +52,20 @@ def _resolve_hints(project_id: Optional[int], image_name: Optional[str], page_w,
     today's only source, still the fallback for projects/images that predate
     this feature or whose staffline detection failed/was skipped).
 
+    Tier 1 is deliberately scoped to the image's CURRENT annotation, not
+    just "the newest succeeded staffline_detections row" -- staffline_detections
+    accumulates forever (never overwritten, unlike annotations' delete-then-
+    insert on re-predict; see documentation_allons-y/STAFFLINE_INTEGRATION_FOLLOWUPS.md),
+    so a project that's been re-annotated/re-predicted since its last
+    staffline detection would otherwise still match on created_at DESC and
+    silently encode against geometrically stale stave data. Same class of
+    staleness inference_api.py's _load_image_and_yolo_for_detection() already
+    guards against for the interpolate-preview/confirm routes (there, by
+    re-resolving the current annotation via image_id); here, since this
+    function is only ever called with image_name (not image_id), the
+    equivalent guard is: look up the current annotation_id for this image
+    first, then require tier 1's staffline_detections row to match it.
+
     ev, if given, is _encode_one's own event-publishing closure -- used here
     only to emit [trace] lines confirming staves_from_jsomr()'s input/output
     record counts (and whether any stave fell back to its centerline-derived
@@ -76,38 +90,42 @@ def _resolve_hints(project_id: Optional[int], image_name: Optional[str], page_w,
                     text_alignment = json.loads(row[0])
             except Exception:
                 pass
+            current_annotation_id = None
+            current_yolo_txt = None
             try:
                 cur.execute(
-                    "SELECT jsomr_json FROM staffline_detections WHERE image_name=%s AND project_id=%s"
-                    " AND status='succeeded' ORDER BY created_at DESC, id DESC LIMIT 1",
+                    "SELECT id, yolo_txt FROM annotations WHERE image_name = %s AND project_id = %s "
+                    "ORDER BY created_at DESC LIMIT 1",
                     (image_name, project_id),
                 )
                 row = cur.fetchone()
-                if row and row[0]:
-                    jsomr_records = row[0] if isinstance(row[0], list) else json.loads(row[0])
-                    yolo_stave_hints = staffline_adapter.staves_from_jsomr(jsomr_records)
-                    if yolo_stave_hints:
-                        stave_source = "staffline_detection"
-                    if ev:
-                        ev({"type": "log", "message":
-                            f"[trace] {image_name}: staves_from_jsomr: {len(jsomr_records)} JSOMR record(s) in"
-                            f" -> {len(yolo_stave_hints)} stave(s) out"})
+                if row:
+                    current_annotation_id, current_yolo_txt = row
             except Exception:
                 pass
-            if not yolo_stave_hints:
+            if current_annotation_id is not None:
                 try:
                     cur.execute(
-                        "SELECT yolo_txt FROM annotations WHERE image_name = %s AND project_id = %s "
-                        "ORDER BY created_at DESC LIMIT 1",
-                        (image_name, project_id),
+                        "SELECT jsomr_json FROM staffline_detections WHERE image_name=%s AND project_id=%s"
+                        " AND status='succeeded' AND annotation_id=%s ORDER BY created_at DESC, id DESC LIMIT 1",
+                        (image_name, project_id, current_annotation_id),
                     )
                     row = cur.fetchone()
                     if row and row[0]:
-                        yolo_stave_hints = parse_yolo_stave_hints(row[0], page_w, page_h)
+                        jsomr_records = row[0] if isinstance(row[0], list) else json.loads(row[0])
+                        yolo_stave_hints = staffline_adapter.staves_from_jsomr(jsomr_records)
                         if yolo_stave_hints:
-                            stave_source = "yolo_annotation"
+                            stave_source = "staffline_detection"
+                        if ev:
+                            ev({"type": "log", "message":
+                                f"[trace] {image_name}: staves_from_jsomr: {len(jsomr_records)} JSOMR record(s) in"
+                                f" -> {len(yolo_stave_hints)} stave(s) out"})
                 except Exception:
                     pass
+            if not yolo_stave_hints and current_yolo_txt:
+                yolo_stave_hints = parse_yolo_stave_hints(current_yolo_txt, page_w, page_h)
+                if yolo_stave_hints:
+                    stave_source = "yolo_annotation"
             cur.close()
         finally:
             release_db_conn(con)

--- a/landing-page/scripts/tests/test_resolve_hints_staleness.py
+++ b/landing-page/scripts/tests/test_resolve_hints_staleness.py
@@ -1,0 +1,185 @@
+"""Regression test for tasks_encode.py's _resolve_hints() tier-1 staleness
+guard (documentation_allons-y/STAFFLINE_INTEGRATION_FOLLOWUPS.md's
+"stale staffline_detections row" bug).
+
+_resolve_hints imports `tasks_encode`, which imports `auth_api`/`job_store` --
+both of which connect to a live Postgres at *module import time*
+(auth_api.py calls init_db() unconditionally on import, per CLAUDE.md's
+Backend section). test_bbox_pipeline_integrity.py's own docstring
+deliberately avoids importing tasks_encode/staffline_stage for exactly this
+reason, staying one level below at staffline_adapter/encode_to_mei instead.
+
+_resolve_hints' new staleness-guard logic lives inside tasks_encode.py
+itself, so there's no lower-level module to test it through -- this file
+stubs out `auth_api`/`job_store`/`celery_app` in sys.modules *before*
+importing tasks_encode, so the import never touches a real DB or broker.
+A hand-rolled fake cursor then answers each SQL query by inspecting which
+table it targets, tracking exactly what _resolve_hints asked for.
+
+No DB, no Celery, no cv2/scipy/scikit-image.
+"""
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+def _install_db_free_stubs():
+    """Installs minimal auth_api/job_store/celery_app stand-ins so importing
+    tasks_encode doesn't try to reach a real Postgres/Redis. Idempotent --
+    safe to call more than once in the same test session."""
+    if "auth_api" not in sys.modules:
+        auth_api_stub = types.ModuleType("auth_api")
+        auth_api_stub.get_db_conn = lambda: None
+        auth_api_stub.release_db_conn = lambda con: None
+        sys.modules["auth_api"] = auth_api_stub
+
+    if "job_store" not in sys.modules:
+        job_store_stub = types.ModuleType("job_store")
+        job_store_stub.publish_event = lambda *a, **k: None
+        job_store_stub.fetch_upload = lambda *a, **k: None
+        job_store_stub.drop_upload = lambda *a, **k: None
+        job_store_stub.session_put = lambda *a, **k: None
+        job_store_stub.check_cancelled = lambda *a, **k: None
+
+        class _JobCancelled(Exception):
+            pass
+
+        job_store_stub.JobCancelled = _JobCancelled
+        sys.modules["job_store"] = job_store_stub
+
+    if "celery_app" not in sys.modules:
+        celery_app_stub = types.ModuleType("celery_app")
+
+        class _FakeCeleryApp:
+            def task(self, *a, **k):
+                def _decorator(fn):
+                    return fn
+                return _decorator
+
+        celery_app_stub.celery_app = _FakeCeleryApp()
+        sys.modules["celery_app"] = celery_app_stub
+
+
+_install_db_free_stubs()
+
+import tasks_encode  # noqa: E402
+
+
+class FakeCursor:
+    """Answers _resolve_hints' three SELECTs by table name, and records every
+    query it was asked (SQL substring + params) for assertions."""
+
+    def __init__(self, annotations_row=None, staffline_row_by_annotation_id=None,
+                 text_alignment_row=None):
+        self.annotations_row = annotations_row
+        self.staffline_row_by_annotation_id = staffline_row_by_annotation_id or {}
+        self.text_alignment_row = text_alignment_row
+        self.queries = []
+        self._pending = None
+
+    def execute(self, sql, params=()):
+        self.queries.append((sql, params))
+        if "FROM text_alignments" in sql:
+            self._pending = self.text_alignment_row
+        elif "FROM annotations" in sql:
+            self._pending = self.annotations_row
+        elif "FROM staffline_detections" in sql:
+            # params = (image_name, project_id, annotation_id)
+            annotation_id = params[2]
+            self._pending = self.staffline_row_by_annotation_id.get(annotation_id)
+        else:
+            self._pending = None
+
+    def fetchone(self):
+        return self._pending
+
+    def close(self):
+        pass
+
+
+class FakeConnection:
+    pass
+
+
+def _patch_db_conn(monkeypatch, cursor):
+    monkeypatch.setattr(tasks_encode, "get_db_conn", lambda: FakeConnection())
+    monkeypatch.setattr(tasks_encode, "release_db_conn", lambda con: None)
+    monkeypatch.setattr(FakeConnection, "cursor", lambda self: cursor, raising=False)
+
+
+def test_stale_staffline_detection_is_ignored_in_favor_of_current_annotation(monkeypatch):
+    """Two staffline_detections rows exist for this image (accumulate-forever
+    design): an OLDER one, newest by created_at, tied to an annotation_id
+    that is no longer current (the image was re-annotated since). Tier 1
+    must NOT return that stale row's geometry -- it should fall through to
+    tier 2 (parse_yolo_stave_hints on the CURRENT annotation's own yolo_txt)
+    instead of silently encoding against superseded stave data."""
+    current_annotation_id = "ann-current"
+    stale_annotation_id = "ann-old"
+
+    stale_jsomr = [{"stave_id": 0, "bounding_box": {"ulx": 0, "uly": 0, "lrx": 10, "lry": 10},
+                    "centerline_page": {"x_start": 0, "x_end": 10, "y_values": [5] * 11}}]
+
+    cursor = FakeCursor(
+        annotations_row=(current_annotation_id, "2 0.5 0.3 0.9 0.02\n2 0.5 0.35 0.9 0.02"),
+        staffline_row_by_annotation_id={stale_annotation_id: (stale_jsomr,)},
+        text_alignment_row=None,
+    )
+    monkeypatch.setattr(tasks_encode, "get_db_conn", lambda: FakeConnection())
+    monkeypatch.setattr(tasks_encode, "release_db_conn", lambda con: None)
+    monkeypatch.setattr(FakeConnection, "cursor", lambda self: cursor, raising=False)
+
+    _text_alignment, yolo_stave_hints, stave_source = tasks_encode._resolve_hints(
+        project_id=1, image_name="page.jpg", page_w=1000, page_h=1000,
+    )
+
+    # Tier 1 must have been asked to match the CURRENT annotation_id, not
+    # just ordered by created_at with no annotation filter at all.
+    staffline_queries = [q for q in cursor.queries if "FROM staffline_detections" in q[0]]
+    assert len(staffline_queries) == 1
+    assert "annotation_id" in staffline_queries[0][0]
+    assert staffline_queries[0][1][2] == current_annotation_id
+
+    # The stale row (keyed to ann-old) must not have been used.
+    assert stave_source != "staffline_detection"
+    # Falls through to tier 2 instead (real yolo_txt was supplied above).
+    assert stave_source == "yolo_annotation"
+
+
+def test_current_staffline_detection_still_wins_when_it_matches():
+    """Sanity check the fix doesn't over-correct: when the newest
+    staffline_detections row DOES match the current annotation, tier 1
+    should still win over tier 2, same as before this fix."""
+    import pytest
+    monkeypatch = pytest.MonkeyPatch()
+    try:
+        current_annotation_id = "ann-current"
+        fresh_jsomr = [
+            {"stave_id": 0, "within_stave_index": 0,
+             "bounding_box": {"ulx": 0, "uly": 0, "lrx": 700, "lry": 10},
+             "centerline_page": {"x_start": 0, "x_end": 700, "y_values": [5] * 701}},
+        ]
+        cursor = FakeCursor(
+            annotations_row=(current_annotation_id, "2 0.5 0.3 0.9 0.02\n2 0.5 0.35 0.9 0.02"),
+            staffline_row_by_annotation_id={current_annotation_id: (fresh_jsomr,)},
+            text_alignment_row=None,
+        )
+        monkeypatch.setattr(tasks_encode, "get_db_conn", lambda: FakeConnection())
+        monkeypatch.setattr(tasks_encode, "release_db_conn", lambda con: None)
+        monkeypatch.setattr(FakeConnection, "cursor", lambda self: cursor, raising=False)
+
+        _text_alignment, yolo_stave_hints, stave_source = tasks_encode._resolve_hints(
+            project_id=1, image_name="page.jpg", page_w=1000, page_h=1000,
+        )
+
+        assert stave_source == "staffline_detection"
+        assert len(yolo_stave_hints) == 1
+    finally:
+        monkeypatch.undo()
+
+
+if __name__ == "__main__":
+    import pytest
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/landing-page/scripts/tests/test_resolve_hints_staleness.py
+++ b/landing-page/scripts/tests/test_resolve_hints_staleness.py
@@ -131,7 +131,7 @@ def test_stale_staffline_detection_is_ignored_in_favor_of_current_annotation(mon
     monkeypatch.setattr(tasks_encode, "release_db_conn", lambda con: None)
     monkeypatch.setattr(FakeConnection, "cursor", lambda self: cursor, raising=False)
 
-    _text_alignment, yolo_stave_hints, stave_source = tasks_encode._resolve_hints(
+    _text_alignment, _yolo_stave_hints, stave_source = tasks_encode._resolve_hints(
         project_id=1, image_name="page.jpg", page_w=1000, page_h=1000,
     )
 
@@ -170,12 +170,12 @@ def test_current_staffline_detection_still_wins_when_it_matches():
         monkeypatch.setattr(tasks_encode, "release_db_conn", lambda con: None)
         monkeypatch.setattr(FakeConnection, "cursor", lambda self: cursor, raising=False)
 
-        _text_alignment, yolo_stave_hints, stave_source = tasks_encode._resolve_hints(
+        _text_alignment, _yolo_stave_hints, stave_source = tasks_encode._resolve_hints(
             project_id=1, image_name="page.jpg", page_w=1000, page_h=1000,
         )
 
         assert stave_source == "staffline_detection"
-        assert len(yolo_stave_hints) == 1
+        assert len(_yolo_stave_hints) == 1
     finally:
         monkeypatch.undo()
 


### PR DESCRIPTION
## Summary

Kyrie reported `Plimpton041_167v` producing visibly worse staffline-detection results through mothra-landing (deployed) than through a local `staff-finding` pipeline run, verified with a direct comparison: local runs consistently group 5 staves cleanly at mode 4 lines/stave (correct for this manuscript), while the deployed run's `staffline_detections` JSOMR showed `lines_expected: 2`.

Investigation ruled out a `staff-finding/` algorithm regression: the package's own code and bundled `.pt` model weights are identical between local and deployed. Two real causes were found instead:

1. **Local checkout was 50 commits behind `origin/main`** (what's actually deployed), including several staffline-integration-specific fixes already live. This PR is branched fresh from `main` so the diagnosis isn't chasing an already-fixed gap.
2. **A real, independent staleness bug in `tasks_encode.py`'s `_resolve_hints()`**: tier 1 picked the newest `succeeded` `staffline_detections` row by `created_at` alone, with no check that it matched the image's *current* annotation. Since that table accumulates forever (unlike `annotations`' delete-then-insert), a project re-annotated/re-predicted since its last staffline detection could silently encode against stale stave geometry -- exactly the scenario a fresh local DB never hits, but a long-running deployed DB eventually does. `inference_api.py`'s interpolate-preview/confirm routes already guarded against this same class of staleness; this PR applies the equivalent guard to `_resolve_hints`.

Also reviewed (not merged, not built against yet): `gianna/calvo-integration` is an ink-separation front-end, not a bounding-box detector -- box format (`STAFFLINE_CLASS_ID=2`, plain YOLO-txt) is unchanged, so no format-level blocker for `staff-finding/` once it merges. Notes captured in the followups doc for what to validate at that point.

## Changes

- `landing-page/scripts/tasks_encode.py` -- `_resolve_hints()` now resolves the image's current annotation first, then requires tier-1's `staffline_detections` row to match that annotation's id, falling through to tier 2 otherwise.
- `landing-page/scripts/tests/test_resolve_hints_staleness.py` -- new regression test (hand-rolled fake cursor + `sys.modules` stubs for `auth_api`/`job_store`/`celery_app`, since importing `tasks_encode` for real needs a live Postgres/Redis -- same constraint `test_bbox_pipeline_integrity.py` already documents).
- `documentation_allons-y/STAFFLINE_INTEGRATION_FOLLOWUPS.md` -- full writeup of the diagnosis, the fix, the calvo-integration compatibility review, and next-step suspects if the gap still reproduces once live-verified.

## Verification

- `landing-page/scripts/tests/`: all 10 pre-existing tests + 2 new regression tests pass.
- Local `staff-finding` e2e re-runs of `Plimpton041_167v` (two independent runs) both confirm clean mode-4-lines-per-stave grouping, consistent with the package itself being unaffected.
- **Not verified live**: a real predict-job re-run of `Plimpton041_167v` through this branch's code, since the sandbox this was diagnosed in has no `ic/api/.venv`, `text-service/.venv`, or Redis to run the full `./dev.sh` stack. Documented as the concrete next step (with ordered suspects if the gap still reproduces) in the followups doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved staffline detection handling to ignore outdated results and use the latest annotation data when needed.
  * Ensured matching current detections take precedence over fallback data.

* **Documentation**
  * Added guidance on diagnosing deployment discrepancies and notes for upcoming ink-separation and geometry integrations.

* **Tests**
  * Added regression coverage for stale and current staffline detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->