### PR TITLE
Handle phantom-continuation folios in upload/batch flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ staff-finding/models/
 zzzz/
 staff-finding/addtl-gt/
 
+# Editable-install build artifacts (any package, anywhere in the repo)
+*.egg-info/
+
 # Downloaded pretrained weights
 yolov8*.pt
 *.pt

--- a/landing-page/src/components/project/BatchFolioReviewModal.tsx
+++ b/landing-page/src/components/project/BatchFolioReviewModal.tsx
@@ -16,6 +16,7 @@ const STATUS_LABEL: Record<FolioReviewStatus, string> = {
     mismatch: "⚠ different position",
     "not-in-source": "⚠ not in Cantus source",
     duplicate: "⚠ duplicate folio",
+    "phantom-continuation": "◆ not in Cantus source — continuation (ok)",
 };
 
 const STATUS_COLOR: Record<FolioReviewStatus, string> = {
@@ -24,6 +25,7 @@ const STATUS_COLOR: Record<FolioReviewStatus, string> = {
   mismatch: "text-yellow-700",
   "not-in-source": "text-red-700",
   duplicate: "text-red-700",
+  "phantom-continuation": "text-[#4AADAA]",
 };
 
 export default function BatchFolioReviewModal({

--- a/landing-page/src/components/project/BatchTab.tsx
+++ b/landing-page/src/components/project/BatchTab.tsx
@@ -10,11 +10,14 @@ interface BatchImage {
 interface BatchTabProps {
   batchImages: BatchImage[];
   folioSequence: string[];
+  cantusFolios?: string[];
   onUseBatch: (names: string[]) => void;
   onDiscardBatch: (imageIds: string[]) => void;
 }
 
-export default function BatchTab({ batchImages, folioSequence, onUseBatch, onDiscardBatch }: BatchTabProps) {
+export default function BatchTab({ batchImages, folioSequence, cantusFolios = [], onUseBatch, onDiscardBatch }: BatchTabProps) {
+  const isPhantom = (folio: string | undefined): boolean =>
+    !!folio && cantusFolios.length > 0 && !cantusFolios.includes(folio);
   const [index, setIndex] = useState(0);
   const [expanded, setExpanded] = useState(false);
   const [confirmDiscard, setConfirmDiscard] = useState(false);
@@ -56,8 +59,11 @@ export default function BatchTab({ batchImages, folioSequence, onUseBatch, onDis
             className="w-48 h-64 object-cover rounded-lg border border-white/20"
           />
         </button>
-        <span className="absolute bottom-1 left-1 bg-[#1D3335]/80 text-white text-[10px] font-mono px-1.5 py-0.5 rounded">
-          {index + 1}/{batchImages.length} — {folioSequence[index] ?? "—"}
+        <span
+          className="absolute bottom-1 left-1 bg-[#1D3335]/80 text-white text-[10px] font-mono px-1.5 py-0.5 rounded"
+          title={isPhantom(folioSequence[index]) ? "not in Cantus source — continuation" : undefined}
+        >
+          {index + 1}/{batchImages.length} — {folioSequence[index] ?? "—"}{isPhantom(folioSequence[index]) && " ◆"}
         </span>
       </div>
 
@@ -121,7 +127,8 @@ export default function BatchTab({ batchImages, folioSequence, onUseBatch, onDis
                 className="max-h-[70vh] max-w-full object-contain rounded-lg"
               />
               <p className="text-white/70 text-xs">
-                {index + 1} / {batchImages.length} — folio {folioSequence[index] ?? "—"} — {current.name}
+                {index + 1} / {batchImages.length} — folio {folioSequence[index] ?? "—"}
+                {isPhantom(folioSequence[index]) && " ◆ (not in Cantus source — continuation)"} — {current.name}
               </p>
             </div>
             <button

--- a/landing-page/src/components/project/CantusSourcePanel.tsx
+++ b/landing-page/src/components/project/CantusSourcePanel.tsx
@@ -4,6 +4,7 @@ import { apiFetchOrThrow } from "../../lib/apiFetch";
 import type { useTextFindingSettings } from "../../hooks/useTextFindingSettings";
 import { findFolioConflict, compareFolios } from "../../utils/folio";
 import { downloadBlob } from "../../utils/download";
+import FolioSelect from "../shared/FolioSelect";
 
 // Persists across CantusSourcePanel unmount/remount (e.g. navigating to the
 // processing/IC view and back) so a slow or failed background revalidation
@@ -190,19 +191,15 @@ export default function CantusSourcePanel({
                     {exportError && <p className="text-red-200 text-xs">{exportError}</p>}
                 {imageSubTab === "grid" ? (
                     <>
-                        <select
+                        <FolioSelect
                             value={folio}
-                            onChange={(e) => {
-                                patch({ folio: e.target.value });
-                                setConflict(findFolioConflict(project.images, e.target.value) ?? null);
+                            options={loadedSource.folios}
+                            onChange={(v) => {
+                                patch({ folio: v });
+                                setConflict(findFolioConflict(project.images, v) ?? null);
                             }}
                             className="bg-[#1D3335] border border-white/30 rounded px-2 py-1 text-sm text-white outline-none w-40"
-                        >
-                            <option value="">select folio...</option>
-                            {loadedSource.folios.map((f) => (
-                            <option key={f} value={f}>{f}</option>
-                            ))}
-                        </select>
+                        />
                         {conflict && (
                             <p className="text-yellow-200 text-xs">
                                 ⚠ folio "{folio}" is already used by {conflict.name}
@@ -223,25 +220,21 @@ export default function CantusSourcePanel({
                         <div className="flex gap-4">
                             <label className="flex flex-col gap-1">
                                 <span className="text-xs text-white/70">start folio</span>
-                                <select
+                                <FolioSelect
                                     value={batchStartFolio}
-                                    onChange={(e) => onBatchStartFolioChange(e.target.value)}
+                                    options={loadedSource.folios}
+                                    onChange={onBatchStartFolioChange}
                                     className="bg-[#1D3335] border border-white/30 rounded px-2 py-1 text-sm text-white outline-none w-32"
-                                >
-                                    <option value="">select...</option>
-                                    {loadedSource.folios.map((f) => <option key={f} value={f}>{f}</option>)}
-                                </select>
+                                />
                             </label>
                             <label className="flex flex-col gap-1">
                                 <span className="text-xs text-white/70">end folio</span>
-                                <select
+                                <FolioSelect
                                     value={batchEndFolio}
-                                    onChange={(e) => onBatchEndFolioChange(e.target.value)}
+                                    options={loadedSource.folios}
+                                    onChange={onBatchEndFolioChange}
                                     className="bg-[#1D3335] border border-white/30 rounded px-2 py-1 text-sm text-white outline-none w-32"
-                                >
-                                    <option value="">select...</option>
-                                    {loadedSource.folios.map((f) => <option key={f} value={f}>{f}</option>)}
-                                </select>
+                                />
                             </label>
                         </div>
                         {batchFolioSequence.length > 0 ? (

--- a/landing-page/src/components/project/EditFolioModel.tsx
+++ b/landing-page/src/components/project/EditFolioModel.tsx
@@ -1,6 +1,7 @@
 import Modal from "../shared/Modal";
 import type { ProjectImage } from "../../types";
 import { findFolioConflict } from "../../utils/folio";
+import FolioSelect from "../shared/FolioSelect";
 
 interface EditFolioModalProps {
     image: ProjectImage;
@@ -19,17 +20,14 @@ export default function EditFolioModal({
   return (
     <Modal onClose={onClose}>
       <h2 className="text-xl text-[#1D3335] text-center">edit folio — {image.name}</h2>
-      <select
+      <FolioSelect
         autoFocus
         value={value}
-        onChange={(e) => onChange(e.target.value)}
+        options={folioOptions}
+        onChange={onChange}
+        placeholder="no folio"
         className="bg-white rounded-2xl px-6 py-3 text-center text-[#1D3335] outline-none text-sm"
-      >
-        <option value="">no folio</option>
-        {folioOptions.map((f) => (
-          <option key={f} value={f}>{f}</option>
-        ))}
-      </select>
+      />
       {conflict && (
         <p className="text-red-600 text-xs text-center">
           ⚠ folio "{value}" is already used by {conflict.name}

--- a/landing-page/src/components/project/ImageTab.tsx
+++ b/landing-page/src/components/project/ImageTab.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, useMemo } from "react";
 import { toast } from "../../lib/toast";
-import { compareFolios, extractFolioFromFilename, matchCanonicalFolio } from "../../utils/folio";
+import { compareFolios, extractFolioFromFilename, matchCanonicalFolio, buildEffectiveFolioSequence } from "../../utils/folio";
 import type { FolioReviewRow } from "../../utils/folio";
 import BatchFolioReviewModal from "./BatchFolioReviewModal";
 import type { Project, ProjectImage } from "../../types";
@@ -204,8 +204,26 @@ export default function ImageTab({
     return results;
   };
 
-  const folioAt = (seq: number): string | undefined => 
-    imageSubTab === "batch" ? batchFolioSequence[batchImages.length + seq] : activeFolio;
+  // Working copy of batchFolioSequence that can grow when a phantom-continuation
+  // folio (e.g. "003r", not in Cantus DB's list but recognized as a genuine
+  // single-step gap - see buildEffectiveFolioSequence) is spliced in for this
+  // batch session. Reset whenever the upstream canonical sequence changes
+  // (new range picked, or reset after "use batch"/"discard batch").
+  const [effectiveFolioSequence, setEffectiveFolioSequence] = useState<string[]>(batchFolioSequence);
+  useEffect(() => {
+    setEffectiveFolioSequence(batchFolioSequence);
+  }, [batchFolioSequence]);
+
+  // True when an image's folio was accepted despite not being in Cantus DB's
+  // list for the currently-loaded source (a phantom-continuation folio like
+  // "003r", or a manually-typed custom folio) - no persisted flag needed,
+  // this is just list membership checked at render time. Guarded on
+  // sourceId so an image from a different/unloaded source never false-positives.
+  const isPhantomFolio = (img: ProjectImage): boolean =>
+    !!img.folio && img.sourceId === cantusSourceId && cantusFolios.length > 0 && !cantusFolios.includes(img.folio);
+
+  const folioAt = (seq: number): string | undefined =>
+    imageSubTab === "batch" ? effectiveFolioSequence[batchImages.length + seq] : activeFolio;
 
   const [pendingBatchReview, setPendingBatchReview] = useState<{
     imageFiles: File[];
@@ -218,6 +236,7 @@ export default function ImageTab({
     pdfPageFiles: File[];
     oversized: File[];
     folioOverride?: Map<string, string>;
+    batchPositionalFolios?: (string | undefined)[];
   } | null>(null);
   const [resizing, setResizing] = useState(false);
 
@@ -227,13 +246,23 @@ export default function ImageTab({
   }
 
   const computeFolioReviewRows = (imageFiles: File[]): FolioReviewRow[] => {
+    // Reconcile against a phantom-continuation folio (e.g. "003r") the same
+    // way the actual upload will (see runBatchUpload) - computed fresh here
+    // rather than read from folioAt/effectiveFolioSequence, since that state
+    // hasn't been committed for THIS set of files yet at review time.
+    const remaining = imageSubTab === "batch" ? effectiveFolioSequence.slice(batchImages.length) : [];
+    const { sequence: reconciled, isPhantom } =
+      imageSubTab === "batch"
+        ? buildEffectiveFolioSequence(remaining, imageFiles.map((f) => extractFolioFromFilename(f.name)))
+        : { sequence: imageFiles.map((_, i) => folioAt(i)), isPhantom: imageFiles.map(() => false) };
+
     const parsed = imageFiles.map((f, i) => {
-      const positionalFolio = folioAt(i);
+      const positionalFolio = reconciled[i];
       const detectedRaw = extractFolioFromFilename(f.name);
-      const detectedCanonical = 
+      const detectedCanonical =
         detectedRaw === undefined ? undefined : matchCanonicalFolio(cantusFolios, detectedRaw);
       const notInSource = detectedRaw !== undefined && cantusFolios.length > 0 && detectedCanonical === undefined;
-      return { fileName: f.name, positionalFolio, detectedRaw, detectedCanonical, notInSource};
+      return { fileName: f.name, positionalFolio, detectedRaw, detectedCanonical, notInSource, isPhantom: isPhantom[i] };
     });
 
     // only group folios that actually resolved to a canonical value - never
@@ -243,11 +272,20 @@ export default function ImageTab({
       if (p.detectedCanonical) counts.set(p.detectedCanonical, (counts.get(p.detectedCanonical) ?? 0) + 1);
     }
 
-    // precedence: duplicate > not-in-source > mismatch > no-detection > match
+    // precedence: duplicate > phantom-continuation > not-in-source > mismatch > no-detection > match
     return parsed.map((p): FolioReviewRow => {
       const isDuplicate = !!p.detectedCanonical && (counts.get(p.detectedCanonical) ?? 0) > 1;
       if (isDuplicate) {
         return { fileName: p.fileName, positionalFolio: p.positionalFolio, detectedFolio: p.detectedCanonical, status: "duplicate" };
+      }
+      // a recognized phantom-continuation folio also satisfies notInSource
+      // below (it's genuinely not in Cantus DB's list) - must be checked
+      // first so it's surfaced as an accepted case, not a warning.
+      if (p.isPhantom) {
+        // positionalFolio here IS the phantom folio, already re-padded to
+        // match its siblings (see buildEffectiveFolioSequence) - show that,
+        // not the raw filename guess, which may have stripped leading zeros.
+        return { fileName: p.fileName, positionalFolio: p.positionalFolio, detectedFolio: p.positionalFolio, status: "phantom-continuation" };
       }
       if (p.notInSource) {
         return { fileName: p.fileName, positionalFolio: p.positionalFolio, detectedFolio: p.detectedRaw, status: "not-in-source" };
@@ -272,6 +310,12 @@ export default function ImageTab({
     imageUploads: PendingUpload[],
     pdfUploads: PendingUpload[],
     folioOverride?: Map<string, string>,
+    // Freshly-reconciled per-file folios for this batch call (image uploads
+    // first, then pdf uploads, matching the shared `seq` counter below) -
+    // takes precedence over folioAt()'s plain positional lookup so a
+    // phantom-continuation folio spliced in by runBatchUpload actually gets
+    // assigned instead of the too-short canonical sequence's next entry.
+    batchPositionalFolios?: (string | undefined)[],
   ) => {
     type UploadEntry = {
       id: string;
@@ -295,7 +339,8 @@ export default function ImageTab({
       // already succeeded - a retry would otherwise re-upload the same file
       const imageSettled = await Promise.allSettled(
         imageUploads.map(async ({ file: f, originalFile }): Promise<UploadEntry> => {
-          const folio = folioOverride?.get(f.name) ?? folioAt(seq++);
+          const idx = seq++;
+          const folio = folioOverride?.get(f.name) ?? batchPositionalFolios?.[idx] ?? folioAt(idx);
           // only associate with the loaded Cantus source when this upload is
           // actually being tagged with a folio - otherwise a source loaded
           // for an earlier batch/folio pick silently leaks onto unrelated
@@ -320,7 +365,8 @@ export default function ImageTab({
 
       const pdfSettled = await Promise.allSettled(
         pdfUploads.map(async ({ file: f, originalFile }): Promise<UploadEntry> => {
-          const pdfFolio = folioAt(seq++);
+          const idx = seq++;
+          const pdfFolio = batchPositionalFolios?.[idx] ?? folioAt(idx);
           const result = await onUploadImage(
             f, pdfFolio, pdfFolio ? cantusSourceId : undefined, pdfFolio ? cantusSourceName : undefined,
             originalFile,
@@ -422,10 +468,30 @@ export default function ImageTab({
 
       const combined = [...imageFiles, ...pdfPageFiles];
       const oversized = getOversizedFiles(combined);
+
+      // Reconcile a phantom-continuation folio (e.g. "003r") into this
+      // batch's remaining folio slots, then commit the extension so later
+      // uploads within the same batch session index correctly. Only image
+      // filenames carry a decodable folio guess - pdf page filenames never
+      // do, so they always fall back to plain positional assignment here,
+      // same as before.
+      let batchPositionalFolios: (string | undefined)[] | undefined;
+      if (imageSubTab === "batch") {
+        const remaining = effectiveFolioSequence.slice(batchImages.length);
+        const guesses = combined.map((f) => extractFolioFromFilename(f.name));
+        const { sequence, canonicalConsumed } = buildEffectiveFolioSequence(remaining, guesses);
+        batchPositionalFolios = sequence;
+        setEffectiveFolioSequence((prev) => [
+          ...prev.slice(0, batchImages.length),
+          ...sequence.filter((f): f is string => f !== undefined),
+          ...remaining.slice(canonicalConsumed),
+        ]);
+      }
+
       if (oversized.length > 0) {
         setConverting(false);
         section.setUploadModal(false);
-        setPendingSizeWarning({ imageFiles, pdfPageFiles, oversized, folioOverride });
+        setPendingSizeWarning({ imageFiles, pdfPageFiles, oversized, folioOverride, batchPositionalFolios });
         return;
       }
 
@@ -433,6 +499,7 @@ export default function ImageTab({
         imageFiles.map((file) => ({ file })),
         pdfPageFiles.map((file) => ({ file })),
         folioOverride,
+        batchPositionalFolios,
       );
 
     } catch (err) {
@@ -444,7 +511,7 @@ export default function ImageTab({
 
   const resolveSizeWarning = async (action: "resize" | "asis" | "cancel") => {
     if (!pendingSizeWarning) return;
-    const { imageFiles, pdfPageFiles, oversized, folioOverride } = pendingSizeWarning;
+    const { imageFiles, pdfPageFiles, oversized, folioOverride, batchPositionalFolios } = pendingSizeWarning;
 
     if (action === "cancel") {
       setPendingSizeWarning(null);
@@ -459,6 +526,7 @@ export default function ImageTab({
         imageFiles.map((file) => ({ file })),
         pdfPageFiles.map((file) => ({ file })),
         folioOverride,
+        batchPositionalFolios,
       );
       return;
     }
@@ -478,7 +546,7 @@ export default function ImageTab({
     ]);
     setResizing(false);
     setPendingSizeWarning(null);
-    await finishUpload(imageUploads, pdfUploads, folioOverride);
+    await finishUpload(imageUploads, pdfUploads, folioOverride, batchPositionalFolios);
   }
 
   const handleFiles = async (files: FileList | File[]) => {
@@ -526,7 +594,7 @@ export default function ImageTab({
     const override = useDetected
       ? new Map(
         rows
-          .filter((r) => (r.status === "match" || r.status === "mismatch") && r.detectedFolio)
+          .filter((r) => (r.status === "match" || r.status === "mismatch" || r.status === "phantom-continuation") && r.detectedFolio)
           .map((r) => [r.fileName, r.detectedFolio!] as const),
       )
       : undefined;
@@ -599,7 +667,8 @@ export default function ImageTab({
         {imageSubTab === "batch" ? (
           <BatchTab
             batchImages={batchImages}
-            folioSequence={batchFolioSequence}
+            folioSequence={effectiveFolioSequence}
+            cantusFolios={cantusFolios}
             onUseBatch={handleUseBatch}
             onDiscardBatch={handleDiscardBatch}
           />
@@ -624,8 +693,11 @@ export default function ImageTab({
             }
             topLeftBadge={(img) =>
               img.folio ? (
-                <span className="bg-[#1D3335]/80 text-white text-[10px] font-mono px-1.5 py-0.5 rounded">
-                  {img.folio}
+                <span
+                  className="bg-[#1D3335]/80 text-white text-[10px] font-mono px-1.5 py-0.5 rounded"
+                  title={isPhantomFolio(img) ? "not in Cantus source — continuation" : undefined}
+                >
+                  {img.folio}{isPhantomFolio(img) && " ◆"}
                 </span>
               ) : null
             }
@@ -788,8 +860,11 @@ export default function ImageTab({
                     <TruncatedName name={img.name} className="text-white" />
                   </div>
                   {img.folio && (
-                    <span className="self-end bg-[#1D3335]/80 text-white text-[10px] font-mono px-1.5 py-0.5 rounded">
-                      {img.folio}
+                    <span
+                      className="self-end bg-[#1D3335]/80 text-white text-[10px] font-mono px-1.5 py-0.5 rounded"
+                      title={isPhantomFolio(img) ? "not in Cantus source — continuation" : undefined}
+                    >
+                      {img.folio}{isPhantomFolio(img) && " ◆"}
                     </span>
                   )}
                   <div className="flex justify-between gap-4">

--- a/landing-page/src/components/project/ProjectDetail.tsx
+++ b/landing-page/src/components/project/ProjectDetail.tsx
@@ -113,7 +113,15 @@ export default function ProjectDetail({
     if (!batchStartFolio || !batchEndFolio) return [];
     const startIdx = folios.indexOf(batchStartFolio);
     const endIdx = folios.indexOf(batchEndFolio);
-    if (startIdx === -1 || endIdx === -1 || startIdx > endIdx) return [];
+    // A manually-typed (off-canonical) start/end boundary - via FolioSelect's
+    // "custom folio..." entry - won't be found by indexOf. Manual entry
+    // doesn't need the adjacency gate auto-detection uses (the human already
+    // vouched for it), so trust it outright rather than collapsing the whole
+    // range to empty the way a genuine not-found value used to.
+    if (startIdx === -1 && endIdx === -1) return [batchStartFolio, batchEndFolio];
+    if (startIdx === -1) return endIdx === -1 ? [] : [batchStartFolio, ...folios.slice(0, endIdx + 1)];
+    if (endIdx === -1) return [...folios.slice(startIdx), batchEndFolio];
+    if (startIdx > endIdx) return [];
     return folios.slice(startIdx, endIdx + 1);
   }, [loadedCantusSource, batchStartFolio, batchEndFolio]);
   const nextStep = useMemo(

--- a/landing-page/src/components/shared/FolioSelect.tsx
+++ b/landing-page/src/components/shared/FolioSelect.tsx
@@ -1,0 +1,98 @@
+import { useState } from "react";
+import { isValidFolioShape } from "../../utils/folio";
+
+interface FolioSelectProps {
+  value: string;
+  options: string[];
+  onChange: (v: string) => void;
+  className?: string;
+  placeholder?: string;
+  autoFocus?: boolean;
+}
+
+const CUSTOM_VALUE = "__custom__";
+
+/**
+ * Folio picker: a `<select>` of the canonical (Cantus DB) options, plus a
+ * "custom folio…" entry that swaps to a free-text input for folios Cantus DB
+ * doesn't list (e.g. a phantom-continuation folio like "003r", or any folio
+ * a human wants to name by hand). Exposes the same `onChange(v: string)`
+ * contract a plain `<select>` would, so callers' existing conflict-detection
+ * etc. keeps working unmodified regardless of which control produced the value.
+ */
+export default function FolioSelect({
+  value,
+  options,
+  onChange,
+  className,
+  placeholder = "select folio...",
+  autoFocus,
+}: FolioSelectProps) {
+  // Start in custom mode if we're editing a folio that's already off-canonical,
+  // so re-opening a picker on a phantom-tagged image shows the typed value,
+  // not a blank dropdown that appears to have lost it.
+  const [customMode, setCustomMode] = useState(() => !!value && !options.includes(value));
+  const [customInput, setCustomInput] = useState(() => (customMode ? value : ""));
+
+  if (customMode) {
+    const invalid = customInput !== "" && !isValidFolioShape(customInput);
+    return (
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center gap-2">
+          <input
+            autoFocus={autoFocus}
+            value={customInput}
+            onChange={(e) => {
+              const v = e.target.value;
+              setCustomInput(v);
+              if (v === "" || isValidFolioShape(v)) onChange(v);
+            }}
+            placeholder="e.g. 003r"
+            className={className}
+          />
+          <button
+            type="button"
+            onClick={() => {
+              setCustomMode(false);
+              setCustomInput("");
+              onChange("");
+            }}
+            className="text-xs underline opacity-70 hover:opacity-100 cursor-pointer whitespace-nowrap"
+          >
+            back to list
+          </button>
+        </div>
+        {invalid && (
+          <p className="text-red-400 text-xs">
+            should look like "003r" or "003" — digits, optionally followed by r/v
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <select
+      autoFocus={autoFocus}
+      value={value}
+      onChange={(e) => {
+        if (e.target.value === CUSTOM_VALUE) {
+          setCustomMode(true);
+          setCustomInput("");
+          onChange("");
+          return;
+        }
+        onChange(e.target.value);
+      }}
+      className={className}
+    >
+      <option value="">{placeholder}</option>
+      {options.map((f) => (
+        <option key={f} value={f}>
+          {f}
+        </option>
+      ))}
+      <option value={CUSTOM_VALUE}>custom folio…</option>
+    </select>
+  );
+}

--- a/landing-page/src/utils/folio.ts
+++ b/landing-page/src/utils/folio.ts
@@ -1,6 +1,12 @@
 import type { ProjectImage } from "../types";
 
-export type FolioReviewStatus = "match" | "no-detection" | "mismatch" | "not-in-source" | "duplicate";
+export type FolioReviewStatus =
+    | "match"
+    | "no-detection"
+    | "mismatch"
+    | "not-in-source"
+    | "duplicate"
+    | "phantom-continuation";
 
 export interface FolioReviewRow {
     fileName: string;
@@ -117,4 +123,132 @@ export function matchCanonicalFolio(folios: string[], candidate: string): string
         if (fn === Number.MAX_SAFE_INTEGER) return false;
         return fn === num && fs === side;
     });
+}
+
+/** [number, side] — mirrors mothra-text/run_chain.py's _parse_folio_id. Unlike
+ * folioSortKey, side is undefined (not defaulted to recto) when the string
+ * has no r/v marker at all, since contiguity rules differ for bare numbers. */
+function parseFolioId(folioId: string): [number, "r" | "v" | undefined] | [undefined, undefined] {
+    const m = /^(\d+)([rv]?)$/i.exec(folioId.trim());
+    if (!m) return [undefined, undefined];
+    const side = m[2] ? (m[2].toLowerCase() as "r" | "v") : undefined;
+    return [Number(m[1]), side];
+}
+
+/** Formats (number, side) as a folio label matching `reference`'s digit
+ * width and letter case (e.g. reference "002v", num=3, side="r" -> "003r").
+ * Needed because extractFolioFromFilename deliberately strips leading
+ * zeros from its raw guess (so it can be resolved against the canonical
+ * list) - for a phantom-continuation folio there's no canonical entry to
+ * resolve against, so the stripped guess must be re-padded by hand to match
+ * its zero-padded siblings instead of standing out as e.g. "3r" next to "002v"/"003v". */
+function formatFolioLike(reference: string, num: number, side: "r" | "v" | undefined): string {
+    const m = /^(0*)(\d+)([rv]?)$/i.exec(reference.trim());
+    const digitWidth = m ? m[1].length + m[2].length : String(num).length;
+    const referenceSide = m?.[3] ?? "";
+    const isUpper = referenceSide !== "" && referenceSide === referenceSide.toUpperCase();
+    const sideChar = side ?? "";
+    return `${String(num).padStart(digitWidth, "0")}${isUpper ? sideChar.toUpperCase() : sideChar.toLowerCase()}`;
+}
+
+/** Returns true if folio `b` directly follows folio `a` in manuscript
+ * sequence (same number r->v, or number+1 v->r / bare-number+1) — port of
+ * mothra-text/run_chain.py's _are_contiguous. Used to recognize a genuine
+ * single-step numbering gap rather than guessing at an arbitrary jump. */
+export function areFoliosContiguous(a: string, b: string): boolean {
+    const [numA, sideA] = parseFolioId(a);
+    const [numB, sideB] = parseFolioId(b);
+    if (numA === undefined || numB === undefined) return false;
+    if (sideA === undefined && sideB === undefined) return numB === numA + 1;
+    if (sideA === "r" && sideB === "v") return numA === numB;
+    if (sideA === "v" && sideB === "r") return numB === numA + 1;
+    return false;
+}
+
+/** Shape-check for a manually-typed folio label (e.g. "003r") — the same
+ * number[+side] pattern folioSortKey/parseFolioId parse. */
+export function isValidFolioShape(input: string): boolean {
+    return /^\s*0*\d+[rv]?\s*$/i.test(input);
+}
+
+export interface EffectiveFolioSequence {
+    /** One entry per input guess - undefined where neither a canonical nor a phantom folio could be resolved. */
+    sequence: (string | undefined)[];
+    /** Parallel to `sequence` - true where that entry is a recognized phantom-continuation folio. */
+    isPhantom: boolean[];
+    /** How many entries of `canonical` were consumed - callers with more files to place (e.g. PDF pages) continue from this index. */
+    canonicalConsumed: number;
+}
+
+/** Reconciles the canonical (Cantus DB) folio list against the folios
+ * guessed from filenames of files about to be uploaded, producing one output
+ * entry per guess.
+ *
+ * A guess that doesn't resolve to the next canonical folio, but is
+ * contiguous with BOTH its already-accepted predecessor and that next
+ * canonical entry, is a genuine single-step gap (e.g. a "phantom
+ * continuation" folio like 003r that Cantus DB doesn't catalogue because no
+ * chant starts there) and gets spliced in without consuming a canonical
+ * slot. This is safe specifically because there IS an uploaded file for it -
+ * it isn't inventing a folio, only recognizing one the user already has.
+ * Anything else falls back to today's plain positional behaviour (assign the
+ * next canonical folio regardless of what the filename suggests).
+ *
+ * A batch that starts exactly at a phantom folio, or ends exactly before its
+ * next canonical neighbor is available, has no contiguity to check against
+ * and can't be auto-detected here - that's the expected point where manual
+ * entry (the "custom folio..." picker) takes over. */
+export function buildEffectiveFolioSequence(
+    canonical: string[],
+    detectedGuesses: (string | undefined)[],
+): EffectiveFolioSequence {
+    const sequence: (string | undefined)[] = [];
+    const isPhantom: boolean[] = [];
+    let c = 0;
+    let lastAccepted: string | undefined;
+
+    for (const guess of detectedGuesses) {
+        const nextCanonical = canonical[c];
+        const resolvesToNext =
+            guess !== undefined && nextCanonical !== undefined
+                ? matchCanonicalFolio([nextCanonical], guess) !== undefined
+                : false;
+
+        if (resolvesToNext) {
+            sequence.push(nextCanonical);
+            isPhantom.push(false);
+            lastAccepted = nextCanonical;
+            c++;
+            continue;
+        }
+
+        const isGenuineGap =
+            guess !== undefined &&
+            lastAccepted !== undefined &&
+            nextCanonical !== undefined &&
+            areFoliosContiguous(lastAccepted, guess) &&
+            areFoliosContiguous(guess, nextCanonical);
+
+        if (isGenuineGap) {
+            // guess is defined here (isGenuineGap requires it), but re-derive
+            // its (number, side) rather than using the raw string directly -
+            // extractFolioFromFilename strips leading zeros, and there's no
+            // canonical entry here to resolve that padding against.
+            const [num, side] = parseFolioId(guess!);
+            const formatted = num !== undefined ? formatFolioLike(nextCanonical, num, side) : guess!;
+            sequence.push(formatted);
+            isPhantom.push(true);
+            lastAccepted = formatted;
+            // canonical pointer NOT advanced - nextCanonical is still upcoming
+            continue;
+        }
+
+        // fall back to today's positional behavior
+        sequence.push(nextCanonical);
+        isPhantom.push(false);
+        if (nextCanonical !== undefined) lastAccepted = nextCanonical;
+        c++;
+    }
+
+    return { sequence, isPhantom, canonicalConsumed: c };
 }

--- a/text-service/main.py
+++ b/text-service/main.py
@@ -36,6 +36,7 @@ for _f in BATCH_DIR.glob("*.zip"):
 from run_pipeline import run, _build_pipeline_payload, _write_mei_json, _find_tridis_model
 from steps.gt_manifest import fetch_cantus_csv, make_output_stem
 from steps.nw_chant_allocator import _folio_sort_key, read_folio_state
+from run_chain import _are_contiguous
 
 app = FastAPI()
 app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
@@ -414,6 +415,27 @@ async def run_text_batch(
                 try:
                     for i, (image_path, folio, stem) in enumerate(zip(image_paths, folio_list, stems)):
                         logger.info("Folio %d/%d: %s", i + 1, len(folio_list), folio)
+                        # infer_continuation=True (build_flat_text_and_anchors' own
+                        # default) would otherwise let it independently scan the CSV
+                        # for "the nearest preceding folio with a 77 break" and
+                        # re-derive the same wrong continuation even after prev_state
+                        # is reset below - it has no idea this folio's true physical
+                        # predecessor was skipped in this batch, only that no explicit
+                        # prev_folio_state was passed. Must be suppressed in the same
+                        # branch, not just prev_state.
+                        infer_continuation = True
+                        if i > 0 and not _are_contiguous(folio_list[i - 1], folio):
+                            # e.g. a folio was intentionally skipped in this batch (or is
+                            # simply not the next physical page) - carrying the previous
+                            # folio's leftover continuation words into this one would
+                            # silently corrupt its alignment from the very first line.
+                            # Mirrors run_chain.py's identical reset for the CLI chain.
+                            logger.info(
+                                "folio %s: not contiguous with previous folio %s, resetting FolioState",
+                                folio, folio_list[i - 1],
+                            )
+                            prev_state = None
+                            infer_continuation = False
                         mask_json_tmp = None
                         folio_mask_json = parsed_mask_json[i] if i < len(parsed_mask_json) else None
                         mothra_json_path = None
@@ -438,6 +460,7 @@ async def run_text_batch(
                                 column_bimodal_threshold=column_bimodal_threshold,
                                 prev_folio_state=prev_state,
                                 folio_state_out=state_path,
+                                infer_continuation=infer_continuation,
                                 column_count=column_count,
                                 mothra_json_path=mothra_json_path,
                                 padding=mask_padding,


### PR DESCRIPTION
Closes #165.

A folio with no chant-start rows in Cantus DB's CSV (e.g. CH-Fco Ms. 2's 003r, where all its text continues the previous folio's chant) never appears in Cantus DB's own folio list. Since every folio picker in landing-page was sourced only from that list, such a folio couldn't be uploaded at all: batch uploads hit a hard "counts must match" block with no override, and single-image uploads had no way to select it at all.

## What changed

- `landing-page/src/utils/folio.ts`: `areFoliosContiguous` (ports `mothra-text/run_chain.py`'s `_are_contiguous`), `isValidFolioShape`, and `buildEffectiveFolioSequence` — reconciles the canonical folio list against uploaded filenames, recognizing a genuine single-step gap (an uploaded image the user demonstrably has, contiguous with its neighbors) as a phantom-continuation folio rather than an error.
- `ImageTab.tsx`: `effectiveFolioSequence` tracks the reconciled sequence through `runBatchUpload`/`finishUpload`; `computeFolioReviewRows` surfaces a new `"phantom-continuation"` status ahead of `"not-in-source"`; visible badges on grid/QuickLook/BatchTab folio labels.
- New shared `FolioSelect.tsx`: adds a "custom folio…" free-text fallback to the three closed folio `<select>`s (`CantusSourcePanel` ×3, `EditFolioModel`), since single-image uploads have no batch to auto-detect adjacency from and need direct manual entry.
- `ProjectDetail.tsx`: `batchFolioSequence` now trusts a manually-typed off-canonical start/end boundary instead of collapsing to empty.
- `BatchFolioReviewModal.tsx`/`BatchTab.tsx`: distinct, non-error styling for the new status.

## Related backend fix

Testing this end-to-end surfaced a real, independent bug: `text-service`'s `/batch-run` threaded `prev_folio_state` between every folio in a batch unconditionally, with no check that consecutive folios were actually manuscript-adjacent — so skipping a folio (e.g. running 002v then 003v without 003r) silently carried 002v's leftover continuation words into 003v. `text-service/main.py` now imports mothra-text's `_are_contiguous` and resets `prev_folio_state` (and suppresses `infer_continuation`) whenever two folios in a batch aren't truly contiguous, mirroring `run_chain.py`'s existing CLI-side guard.

The `mothra-text` submodule is bumped to pick up that fix plus a second, related one found during the same testing pass (an explicit-but-empty `prev_folio_state` was falling through to a stale CSV-guess instead of being trusted) — both already merged upstream (mothra-text#43, mothra-text#44).

## Verification

- `tsc -b`/`vite build` clean.
- 253/253 mothra-text tests pass.
- Manual reproduction against the live app: the 002v/003r/003v batch now aligns 003v correctly from its first line, the 002v/003v (003r skipped) regression case is unaffected, and single-image upload of a phantom folio works via the new "custom folio…" entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom folio entries when selecting single folios or batch ranges.
  * Added visual indicators and explanations for continuation folios detected during batch review.
  * Improved folio selection with validated custom input and easy switching between standard and custom options.

* **Bug Fixes**
  * Batch uploads and reviews now preserve accurate folio positions, including continuation entries.
  * Automatic continuation handling resets correctly when folios are not sequential.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->