### PR TITLE
Capture per-folio logs and activity entries for batch text-finding runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -509,11 +509,17 @@ separate, repo-admin-level step, done in GitHub's own UI, not this file.
   now downloads a real zip of corrected MEI files (`GET /sources/{id}/cantus-bundle`) for manual
   hand-off, since Cantus Ultimus has no write API; see **Workflow pipeline** above
 - **Batch encoding** — `POST /api/encode-batch` (`batch_api.py`/`tasks_encode.py`) handles multiple XML+image pairs in one job
-- **Batch text-finding logs** — `tasks_text_batch.py` now captures and persists per-folio `log_text`
-  on each `text_alignments` row (scoped between `folio_result` boundaries, with the batch-global
-  preamble landing on the first folio), matching `text_api.py`'s single-folio `/predict` path —
-  previously hard-coded to `""`, which is why the Detected text viewer's "view logs" always showed
-  "no logs recorded for this run"
+- **Batch text-finding logs/activity parity** — `tasks_text_batch.py` now captures and persists
+  per-folio `log_text` on each `text_alignments` row (scoped between `folio_result` boundaries, with
+  the batch-global preamble landing on the first folio), matching `text_api.py`'s single-folio
+  `/predict` path — previously hard-coded to `""`, which is why the Detected text viewer's "view
+  logs" always showed "no logs recorded for this run". It also now calls `_log_activity(...,
+  "text_batch_run", ...)` once per batch run, mirroring `tasks_predict.py`'s `"predict_run"` entry —
+  previously batch text-finding runs left no trace in a project's `activity_log`/exported
+  `activity_log.txt` at all. Note: neither of these feeds `GET /projects/{id}/logs/download`'s
+  `encoding_logs.txt` (that file is unrelated — sourced from `project_logs`'s encoding-step rows,
+  see **Workflow pipeline** step 4); surfacing text-finding logs in that zip export would be a
+  separate, not-yet-implemented feature.
 - **YOLO inference** — `POST /api/predict` is live; `ModelTab` `.h5` uploads are wired up
 - **Stave detection** — `estimate_staves_from_glyphs()` in `encode_to_mei.py` uses real staff-line glyph clustering (primary) with neume Y-gap clustering as fallback; `parse_staves()` / `parse_yolo_stave_hints()` handle YOLO-format stave detections
 - **Staffline detection** — `POST /api/predict` runs connected-component filtering, centerline fitting, and stave grouping on stave-class YOLO boxes (`staffline_stage.py`, wrapping the `staff-finding/` package); results are `tasks_encode.py`'s preferred stave source ahead of `parse_yolo_stave_hints()` — see **Staffline detection** above

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -509,6 +509,11 @@ separate, repo-admin-level step, done in GitHub's own UI, not this file.
   now downloads a real zip of corrected MEI files (`GET /sources/{id}/cantus-bundle`) for manual
   hand-off, since Cantus Ultimus has no write API; see **Workflow pipeline** above
 - **Batch encoding** — `POST /api/encode-batch` (`batch_api.py`/`tasks_encode.py`) handles multiple XML+image pairs in one job
+- **Batch text-finding logs** — `tasks_text_batch.py` now captures and persists per-folio `log_text`
+  on each `text_alignments` row (scoped between `folio_result` boundaries, with the batch-global
+  preamble landing on the first folio), matching `text_api.py`'s single-folio `/predict` path —
+  previously hard-coded to `""`, which is why the Detected text viewer's "view logs" always showed
+  "no logs recorded for this run"
 - **YOLO inference** — `POST /api/predict` is live; `ModelTab` `.h5` uploads are wired up
 - **Stave detection** — `estimate_staves_from_glyphs()` in `encode_to_mei.py` uses real staff-line glyph clustering (primary) with neume Y-gap clustering as fallback; `parse_staves()` / `parse_yolo_stave_hints()` handle YOLO-format stave detections
 - **Staffline detection** — `POST /api/predict` runs connected-component filtering, centerline fitting, and stave grouping on stave-class YOLO boxes (`staffline_stage.py`, wrapping the `staff-finding/` package); results are `tasks_encode.py`'s preferred stave source ahead of `parse_yolo_stave_hints()` — see **Staffline detection** above

--- a/landing-page/scripts/tasks_text_batch.py
+++ b/landing-page/scripts/tasks_text_batch.py
@@ -27,9 +27,13 @@ def run_text_batch_task(job_id, project_id, body):
     then forwards the batch to the text-service's `/batch-run` endpoint and
     relays its SSE progress as `job_events` rows via `publish_event`.
     """
+    pending_logs: list[str] = []
+
     def publish(obj):
         publish_event(job_id, obj)
-    
+        if obj.get("type") == "log":
+            pending_logs.append(obj.get("message", ""))
+
     con = get_db_conn()
     cur = con.cursor()
     try:
@@ -167,18 +171,21 @@ def run_text_batch_task(job_id, project_id, body):
                 image_name = images[idx][0]
                 alignment = ev["text_alignment"]
                 aid = _uuid.uuid4().hex
+                syl_count = len(alignment.get("syl_boxes", []))
+                publish({"type": "log", "message": f"{image_name}: {syl_count} syllable(s) aligned"})
+                log_text = "\n".join(pending_logs)
+                pending_logs = []
                 cur.execute(
                     "INSERT INTO text_alignments"
                     " (id, project_id, image_id, image_name, alignment_json,"
                     " median_line_spacing, syllable_count, log_text)"
                     " VALUES (%s,%s,%s,%s,%s,%s,%s,%s)",
                     (aid, project_id, image_id, image_name, json.dumps(alignment),
-                     alignment.get("median_line_spacing", 0.0), len(alignment.get("syl_boxes", [])), ""),
+                     alignment.get("median_line_spacing", 0.0), syl_count, log_text),
                 )
                 con.commit()
                 if ev.get("debug_data"):
                     text_debug_data[image_name] = ev["debug_data"]
-                publish({"type": "log", "message": f"{image_name}: {len(alignment.get('syl_boxes', []))} syllable(s) aligned"})
                 continue
             if ev.get("type") == "result":
                 if text_debug_data:

--- a/landing-page/scripts/tasks_text_batch.py
+++ b/landing-page/scripts/tasks_text_batch.py
@@ -13,7 +13,7 @@ from PIL import Image
 
 from celery_app import celery_app
 from job_store import publish_event, check_cancelled, JobCancelled
-from auth_api import get_db_conn, release_db_conn
+from auth_api import get_db_conn, release_db_conn, _log_activity
 from models_api import get_model_file_path
 from text_api import TEXT_API_URL, _stream_multipart, _music_boxes_for_image, _mask_json_for_image
 from yolo_inference import resolve_yolo_models, write_annotation
@@ -139,6 +139,10 @@ def run_text_batch_task(job_id, project_id, body):
         if body.get("column_count"):
             publish({"type": "log", "message": f"column count forced to {body['column_count']}"})
         publish({"type": "stage_done", "name": "validating"})
+
+        _log_activity(cur, project_id, "text_batch_run",
+                       f"{yolo_models.model_label} on {len(folios)} folio(s) (source {body['source_id']})")
+        con.commit()
 
         publish({"type": "stage", "name": "processing"})
         text_debug_data: dict = {}

--- a/landing-page/scripts/tests/test_tasks_text_batch_logs.py
+++ b/landing-page/scripts/tests/test_tasks_text_batch_logs.py
@@ -44,6 +44,14 @@ def _install_stubs():
         auth_api_stub.get_db_conn = lambda: None
         auth_api_stub.release_db_conn = lambda con: None
         sys.modules["auth_api"] = auth_api_stub
+    # A different test module (test_resolve_hints_staleness.py) may have
+    # already installed a bare auth_api stub without this attribute --
+    # patch it in regardless of which stub got there first.
+    if not hasattr(sys.modules["auth_api"], "_log_activity"):
+        sys.modules["auth_api"]._log_activity = lambda cur, project_id, action_type, detail="": (
+            cur.execute("INSERT INTO activity_log (project_id, action_type, detail) VALUES (%s, %s, %s)",
+                        (project_id, action_type, detail))
+        )
 
     if "job_store" not in sys.modules:
         job_store_stub = types.ModuleType("job_store")
@@ -107,6 +115,7 @@ class FakeCursor:
     def __init__(self, images_by_id):
         self.images_by_id = images_by_id
         self.inserted_alignments = []
+        self.inserted_activity = []
         self._pending = None
 
     def execute(self, sql, params=()):
@@ -114,6 +123,9 @@ class FakeCursor:
             self._pending = self.images_by_id[params[0]]
         elif "INSERT INTO text_alignments" in sql:
             self.inserted_alignments.append(params)
+            self._pending = None
+        elif "INSERT INTO activity_log" in sql:
+            self.inserted_activity.append(params)
             self._pending = None
         else:
             self._pending = None
@@ -211,6 +223,18 @@ def test_batch_run_scopes_log_text_per_folio(monkeypatch):
     assert "layer separation done" not in folio1_log
     assert "running Kraken segmentation" not in folio1_log
     assert "folio0-specific-log" not in folio1_log
+
+    # One activity_log row for the whole batch run, mirroring
+    # tasks_predict.py's "predict_run" entry -- not a bug fix, this is a new
+    # parity addition so batch text-finding runs are no longer invisible in
+    # the "download all logs" -> activity_log.txt export.
+    assert len(cursor.inserted_activity) == 1
+    project_id, action_type, detail = cursor.inserted_activity[0]
+    assert project_id == 1
+    assert action_type == "text_batch_run"
+    assert "fake-model" in detail
+    assert "2 folio(s)" in detail
+    assert "source 42" in detail
 
 
 if __name__ == "__main__":

--- a/landing-page/scripts/tests/test_tasks_text_batch_logs.py
+++ b/landing-page/scripts/tests/test_tasks_text_batch_logs.py
@@ -1,0 +1,218 @@
+"""Regression test for tasks_text_batch.py's per-folio log_text capture.
+
+run_text_batch_task used to hard-code log_text="" on every text_alignments
+row it inserted (the batch/Cantus-folio path behind POST
+/api/projects/{id}/text-batch/run), unlike text_api.py's stream_text_finding
+(the single-folio /predict path), which already accumulates every
+{"type": "log"} SSE event into log_text. Since the batch path is this app's
+default workflow, "view logs" in the Detected text viewer always showed "no
+logs recorded for this run".
+
+The fix buffers every published log line into `pending_logs` and snapshots +
+resets that buffer at each folio_result boundary, so each folio's log_text
+contains only lines emitted since the previous folio_result (batch-global
+preamble -- model loading, resolution messages, stage announcements, and the
+per-image YOLO/staffline logs that all run up front before any folio_result
+comes back -- lands on the first folio only).
+
+tasks_text_batch imports auth_api/job_store/celery_app/models_api/
+yolo_inference/staffline_stage/text_api, several of which touch a live
+Postgres/Redis or heavy ML deps (torch/ultralytics, cv2/scipy) at import
+time. This stubs all of them as bare module stand-ins in sys.modules
+*before* importing tasks_text_batch, mirroring
+test_resolve_hints_staleness.py's pattern for tasks_encode.
+
+No DB, no Celery, no real YOLO/staffline/text-service calls.
+"""
+import io
+import json
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from PIL import Image
+
+
+def _install_stubs():
+    """Installs minimal stand-ins for every module tasks_text_batch imports
+    that would otherwise touch a live DB/broker or pull in heavy ML deps.
+    Idempotent -- safe to call more than once in the same test session."""
+    if "auth_api" not in sys.modules:
+        auth_api_stub = types.ModuleType("auth_api")
+        auth_api_stub.get_db_conn = lambda: None
+        auth_api_stub.release_db_conn = lambda con: None
+        sys.modules["auth_api"] = auth_api_stub
+
+    if "job_store" not in sys.modules:
+        job_store_stub = types.ModuleType("job_store")
+        job_store_stub.publish_event = lambda *a, **k: None
+        job_store_stub.check_cancelled = lambda *a, **k: None
+
+        class _JobCancelled(Exception):
+            pass
+
+        job_store_stub.JobCancelled = _JobCancelled
+        sys.modules["job_store"] = job_store_stub
+
+    if "celery_app" not in sys.modules:
+        celery_app_stub = types.ModuleType("celery_app")
+
+        class _FakeCeleryApp:
+            def task(self, *a, **k):
+                def _decorator(fn):
+                    return fn
+                return _decorator
+
+        celery_app_stub.celery_app = _FakeCeleryApp()
+        sys.modules["celery_app"] = celery_app_stub
+
+    if "models_api" not in sys.modules:
+        models_api_stub = types.ModuleType("models_api")
+        models_api_stub.get_model_file_path = lambda *a, **k: None
+        sys.modules["models_api"] = models_api_stub
+
+    if "yolo_inference" not in sys.modules:
+        yolo_inference_stub = types.ModuleType("yolo_inference")
+        yolo_inference_stub.resolve_yolo_models = lambda *a, **k: (None, [])
+        yolo_inference_stub.write_annotation = lambda *a, **k: "ann-id"
+        sys.modules["yolo_inference"] = yolo_inference_stub
+
+    if "staffline_stage" not in sys.modules:
+        staffline_stage_stub = types.ModuleType("staffline_stage")
+        staffline_stage_stub.run_staffline_detection = lambda *a, **k: iter([])
+        staffline_stage_stub.has_class = lambda *a, **k: False
+        staffline_stage_stub.STAFFLINE_CLASS_ID = 2
+        sys.modules["staffline_stage"] = staffline_stage_stub
+
+    if "text_api" not in sys.modules:
+        text_api_stub = types.ModuleType("text_api")
+        text_api_stub.TEXT_API_URL = "http://fake-text-service"
+        text_api_stub._stream_multipart = lambda *a, **k: iter([])
+        text_api_stub._music_boxes_for_image = lambda *a, **k: []
+        text_api_stub._mask_json_for_image = lambda *a, **k: None
+        sys.modules["text_api"] = text_api_stub
+
+
+_install_stubs()
+
+import tasks_text_batch  # noqa: E402
+
+
+class FakeCursor:
+    """Answers the project_images SELECT with canned rows and records every
+    text_alignments INSERT's params for assertions."""
+
+    def __init__(self, images_by_id):
+        self.images_by_id = images_by_id
+        self.inserted_alignments = []
+        self._pending = None
+
+    def execute(self, sql, params=()):
+        if "FROM project_images" in sql:
+            self._pending = self.images_by_id[params[0]]
+        elif "INSERT INTO text_alignments" in sql:
+            self.inserted_alignments.append(params)
+            self._pending = None
+        else:
+            self._pending = None
+
+    def fetchone(self):
+        return self._pending
+
+    def close(self):
+        pass
+
+
+class FakeConnection:
+    def commit(self):
+        pass
+
+    def rollback(self):
+        pass
+
+
+class FakeYoloModels:
+    stored_model_id = "model-1"
+    model_label = "fake-model"
+    model_hash = "hash-123"
+
+    def infer(self, img_arr):
+        return ""
+
+
+def _png_bytes():
+    buf = io.BytesIO()
+    Image.new("RGB", (4, 4)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _fake_stream_multipart(url, fields=None, files=None, timeout=None):
+    events = [
+        {"type": "log", "message": "folio0-specific-log"},
+        {"type": "folio_result", "image_index": 0,
+         "text_alignment": {"median_line_spacing": 1.0, "syl_boxes": [{}, {}]}},
+        {"type": "log", "message": "folio1-specific-log"},
+        {"type": "folio_result", "image_index": 1,
+         "text_alignment": {"median_line_spacing": 1.0, "syl_boxes": [{}]}},
+        {"type": "result", "batchId": "b1", "fileCount": 2},
+        {"type": "done"},
+    ]
+    for ev in events:
+        yield "data: " + json.dumps(ev) + "\n"
+
+
+def test_batch_run_scopes_log_text_per_folio(monkeypatch):
+    png = _png_bytes()
+    cursor = FakeCursor(images_by_id={
+        "id-a": ("folioA.png", png, "image/png"),
+        "id-b": ("folioB.png", png, "image/png"),
+    })
+
+    monkeypatch.setattr(tasks_text_batch, "get_db_conn", lambda: FakeConnection())
+    monkeypatch.setattr(tasks_text_batch, "release_db_conn", lambda con: None)
+    monkeypatch.setattr(FakeConnection, "cursor", lambda self: cursor, raising=False)
+    monkeypatch.setattr(tasks_text_batch, "resolve_yolo_models",
+                         lambda *a, **k: (FakeYoloModels(), []))
+    monkeypatch.setattr(tasks_text_batch, "_stream_multipart", _fake_stream_multipart)
+
+    body = {
+        "image_ids": ["id-a", "id-b"],
+        "folios": ["1r", "1v"],
+        "model_preset": "medieval",
+        "yolo_confidence_threshold": 0.5,
+        "yolo_device": "cpu",
+        "masking_enabled": False,
+        "source_id": 42,
+        "device": "cpu",
+        "column_bimodal_threshold": 0.5,
+        "mask_padding": 15,
+    }
+
+    tasks_text_batch.run_text_batch_task("job-1", 1, body)
+
+    assert len(cursor.inserted_alignments) == 2
+    folio0_log = cursor.inserted_alignments[0][-1]
+    folio1_log = cursor.inserted_alignments[1][-1]
+
+    # Folio 0 gets the batch-global preamble (per-image YOLO logs, the
+    # Kraken/HTR stage announcement) plus its own text-service log line and
+    # its own "aligned" summary.
+    assert "layer separation done" in folio0_log
+    assert "running Kraken segmentation" in folio0_log
+    assert "folio0-specific-log" in folio0_log
+    assert "syllable(s) aligned" in folio0_log
+    assert "folio1-specific-log" not in folio0_log
+
+    # Folio 1 gets ONLY its own lines -- no preamble, no folio 0 content.
+    assert "folio1-specific-log" in folio1_log
+    assert "syllable(s) aligned" in folio1_log
+    assert "layer separation done" not in folio1_log
+    assert "running Kraken segmentation" not in folio1_log
+    assert "folio0-specific-log" not in folio1_log
+
+
+if __name__ == "__main__":
+    import pytest
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Batch text-finding (`tasks_text_batch.py`, the default Cantus-aligned workflow behind `POST /text-batch/run`) had two parity gaps against the single-folio `/predict` path.

`text_alignments.log_text` was hard-coded to `""` on every row, so the Detected text viewer's "view logs" always showed "no logs recorded for this run". Each folio's `log_text` is now scoped to the lines emitted since the previous `folio_result` (the batch-global preamble — model loading, resolution messages, per-image YOLO/staffline logs, the Kraken/HTR stage announcement — lands on the first folio), matching `text_api.py`'s `stream_text_finding`.

Batch runs also never called `_log_activity`, so they left no trace in a project's activity log or its exported `activity_log.txt`. This now logs a `text_batch_run` entry once per batch run, mirroring `tasks_predict.py`'s `predict_run`.

Added `test_tasks_text_batch_logs.py` covering both the per-folio log scoping and the new activity-log entry. Also verified manually against the running dev stack: ran a real batch text-finding job and confirmed both the per-folio "view logs" content and the `text_batch_run` activity entry show up as expected.

Closes #183

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Batch text processing now saves detailed alignment logs separately for each folio.
  * Batch runs now create a project activity entry for easier tracking.
  * Alignment summaries are included with each folio’s processing record.

* **Documentation**
  * Clarified that folio alignment logs are not included in existing encoding log exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->