### PR TITLE
encoding/text bbox bug fixes, bump submodule for text_batch bug

### DIFF
--- a/landing-page/scripts/encode_to_mei.py
+++ b/landing-page/scripts/encode_to_mei.py
@@ -208,22 +208,40 @@ def assign_glyphs_to_staves(
 ) -> tuple[dict[int, list[Glyph]], list[StaveBbox]]:
     """Assign each glyph to a stave.
 
-    Detected staves (usually from YOLO stave-class detections) can miss real
-    staff systems entirely — confirmed on a real manuscript page where only 4
-    of 10 real staff-system rows had any stave-class detection at all. Rather
-    than force every glyph onto whichever detected stave is nearest (which
-    corrupts note ordering and pitch for every missed row, since glyphs from
-    multiple distinct physical rows end up interleaved by x-position in one
-    stave's bucket), this reconciles independently-clustered row-groups
-    against the detected staves by Y-range overlap: a row that overlaps a
-    detected stave is assigned to it as before; a row that overlaps nothing
-    is a system the detector missed, and gets a synthesized stave of its own.
+    Two passes, in order:
 
-    That synthesized stave's line_ys (used for pitch computation — see
+    1. Direct claim: each glyph is assigned individually to whichever
+       existing stave's own line band (uly..lry, padded by
+       STAVE_BUFFER_PX) it falls nearest/within -- never to a stave more
+       than STAVE_BUFFER_PX away. This is per-glyph, not per-row-blob, so a
+       lyric-text glyph (or anything else) sitting between two
+       independently-detected staves can never drag a REAL note that IS
+       near its own stave along with it into the wrong bucket, and two
+       real, adjacent, correctly-detected staves can never have their
+       glyphs merged into just one of them and left the other with
+       nothing -- confirmed as a real failure mode on a page where two
+       genuinely-detected, Y-adjacent staves both ended up with zero
+       glyphs after the OLD row-clustering-then-best-overlap-wins design
+       let a lyric-text-bridged row blob's whole content get claimed by a
+       third bucket instead.
+
+    2. Whatever's left unclaimed by pass 1 (mostly lyric-text glyphs that
+       don't sit close enough to any note-line band, plus -- crucially --
+       every glyph belonging to a system the detector missed entirely) is
+       clustered into rows exactly as before (_cluster_glyphs_into_staves),
+       and EACH resulting row is matched to whichever existing stave its
+       own aggregate bbox overlaps most (unchanged blob-level logic); a row
+       that overlaps no existing stave at all is a genuinely missed system
+       and gets a synthesized stave of its own, appended at the end of
+       `staves`. This pass is unchanged from before this fix -- it only
+       ever sees the reduced, already-narrowed-down leftover set, so it
+       can no longer misroute a real note that pass 1 already claimed.
+
+    That synthesized stave's line_ys (used for pitch computation -- see
     _step_from_y) would otherwise come purely from the missed row's own
     glyphs' bounding box (_cluster_glyphs_into_staves's crude fallback),
     which can be badly skewed by that row's own melodic range (a single
-    unusually high/low note inflates the guessed staff height) — confirmed
+    unusually high/low note inflates the guessed staff height) -- confirmed
     on a real page as a visible, per-row-only vertical rendering offset
     (notes floating well above/below their real staff, since Neon/Verovio
     renders pitch, not raw pixel position). Passing this page's OWN
@@ -236,10 +254,7 @@ def assign_glyphs_to_staves(
     same opt-in-fabrication rule as tier-3's own estimate_staves_from_glyphs
     fallback -- without this, a page could end up with tier-3 staves carrying
     synthetic pitch geometry while recovered staves silently didn't, even
-    though the caller asked for synthetic lines everywhere. The two knobs
-    compose: allow_synthetic_lines gates whether a recovered stave gets any
-    line_ys at all, and typical_line_spacing (when synthesis is allowed)
-    decides how reliable that synthesis is.
+    though the caller asked for synthetic lines everywhere.
 
     Returns (glyphs_by_stave, staves) — `staves` may be LONGER than the input
     (synthesized entries appended at the end). Callers must build zones/
@@ -250,26 +265,48 @@ def assign_glyphs_to_staves(
         result: dict[int, list[Glyph]] = {-1: list(glyphs)}
         return result, staves
 
-    typical_spacing = _typical_line_spacing(staves)
-    result = {i: [] for i in range(len(staves))}
-    row_groups = _cluster_glyphs_into_staves(
-        glyphs, page_w, page_h, id_prefix="row", typical_line_spacing=typical_spacing,
-        allow_synthetic_lines=allow_synthetic_lines,
-    )
+    result: dict[int, list[Glyph]] = {i: [] for i in range(len(staves))}
+    unclaimed: list[Glyph] = []
 
-    for row_stave, members in row_groups:
-        best_idx, best_overlap = None, 0
-        for i, stave in enumerate(staves):
-            lo, hi = stave.uly - STAVE_BUFFER_PX, stave.lry + STAVE_BUFFER_PX
-            overlap = min(row_stave.lry, hi) - max(row_stave.uly, lo)
-            if overlap > best_overlap:
-                best_overlap, best_idx = overlap, i
+    def _claim(glyph: Glyph, candidates: list[StaveBbox]) -> Optional[int]:
+        best_idx, best_dist = None, None
+        for i, stave in candidates: 
+            if stave.uly <= glyph.cy <= stave.lry:
+                dist = 0.0
+            else:
+                dist = min(abs(glyph.cy - stave.uly), abs(glyph.cy - stave.lry))
+            if dist <= STAVE_BUFFER_PX and (best_dist is None or dist < best_dist):
+                best_dist, best_idx = dist, i
+        return best_idx
+
+    indexed_staves = list(enumerate(staves))
+    for glyph in glyphs:
+        best_idx = _claim(glyph, indexed_staves)
         if best_idx is not None:
-            result[best_idx].extend(members)
+            result[best_idx].append(glyph)
         else:
-            new_idx = len(staves)
-            staves.append(row_stave)
-            result[new_idx] = list(members)
+            unclaimed.append(glyph)
+
+    if unclaimed:
+        typical_spacing = _typical_line_spacing(staves)
+        row_groups = _cluster_glyphs_into_staves(
+            unclaimed, page_w, page_h, id_prefix="row", typical_line_spacing=typical_spacing,
+            allow_synthetic_lines=allow_synthetic_lines,
+        )
+
+        for row_stave, members in row_groups:
+            best_idx, best_overlap = None, 0
+            for i, stave in enumerate(staves):
+                lo, hi = stave.uly - STAVE_BUFFER_PX, stave.lry + STAVE_BUFFER_PX
+                overlap = min(row_stave.lry, hi) - max(row_stave.uly, lo)
+                if overlap > best_overlap:
+                    best_overlap, best_idx = overlap, i
+            if best_idx is not None:
+                result[best_idx].extend(members)
+            else:
+                new_idx = len(staves)
+                staves.append(row_stave)
+                result[new_idx] = list(members)
     for idx in result:
         result[idx].sort(key=lambda g: g.ulx)
     return result, staves
@@ -1088,9 +1125,12 @@ def build_mei(
         for g in row_groups if len(g) > 1
     }
 
-    for stave_idx in sorted(k for k in glyphs_by_stave if k >= 0):
+    for stave_idx in sorted(
+            (k for k in glyphs_by_stave if k >= 0),
+            key=lambda k: (staves[k].uly, k),
+    ):
         staff_glyphs = glyphs_by_stave[stave_idx]
-        if not staff_glyphs:
+        if not staff_glyphs and not boxes_by_stave.get(stave_idx):
             continue
         # <sb> marks the start of each stave and links it to its zone
         zone_id = stave_zone_ids.get(stave_idx, str(stave_idx))

--- a/landing-page/scripts/encode_to_mei.py
+++ b/landing-page/scripts/encode_to_mei.py
@@ -1299,17 +1299,30 @@ def scale_facsimile(mei_bytes: bytes, factor: float) -> bytes:
                     pass
     return _serialize_mei(root)
 
-def scale_text_alignment(text_alignment: Optional[dict], factor: float) -> Optional[dict]:
-    """Scale a text_alignment's syl_boxes ul/lr coords by factor -- counterpart to
-    scale_facsimile, for when syl_boxes (always computed against the working-copy
-    image) must be compared/written against geometry in a different pixel space."""
-    if not text_alignment or factor == 1.0:
+def scale_text_alignment(text_alignment: Optional[dict], factor_x: float, factor_y: Optional[float] = None) -> Optional[dict]:
+    """Scale a text_alignment's syl_boxes ul/lr coords by (factor_x, factor_y)
+    -- counterpart to scale_facsimile, for when syl_boxes (always computed
+    against the working-copy image) must be compared/written against
+    geometry in a different pixel space.
+
+    factor_x/factor_y are independent, NOT a single uniform scale: the
+    client-side upload resize (imageResize.ts) rounds width and height
+    separately after applying one scalar shrink factor, so
+    image_w/working_w and image_h/working_h can come out numerically
+    different (e.g. an odd source dimension rounds differently on each
+    axis) even though the resize was visually uniform. Using one factor for
+    both axes would skew Y coordinates by that rounding error. factor_y
+    defaults to factor_x for callers that only have (or only need) one
+    axis's ratio."""
+    if factor_y is None:
+        factor_y = factor_x
+    if not text_alignment or (factor_x == 1.0 and factor_y == 1.0):
         return text_alignment
 
     def _scaled(box):
         try:
-            ul = [box["ul"][0] * factor, box["ul"][1] * factor]
-            lr = [box["lr"][0] * factor, box["lr"][1] * factor]
+            ul = [box["ul"][0] * factor_x, box["ul"][1] * factor_y]
+            lr = [box["lr"][0] * factor_x, box["lr"][1] * factor_y]
         except (KeyError, TypeError, IndexError):
             return box  # malformed box passes through unscaled, not dropped
         return {**box, "ul": ul, "lr": lr}

--- a/landing-page/scripts/encode_to_mei.py
+++ b/landing-page/scripts/encode_to_mei.py
@@ -1661,6 +1661,23 @@ def verify_and_correct_syllables(
     staff_zone_id_by_idx = {i: f"sz-{stave.id}" for i, stave in enumerate(staves)}
     logs: list[str] = []
 
+    # A box that's genuinely a fragment-pooled row-mate's (see
+    # _pool_group_syllable_data) can be Y-bucketed here, unpooled, to a
+    # DIFFERENT stave than the one whose glyphs it's actually paired with —
+    # that stave then computes it as a real box with zero glyphs matched,
+    # even though its true glyphs (and its already-correct <syllable>) live
+    # on the row-mate. Detecting that specific case doesn't need re-running
+    # the pooling (out of scope here, see below) -- it only needs to know
+    # whether this exact text is ALREADY backed by real glyphs somewhere
+    # else in the document; if so, this glyph-less copy is that duplicate,
+    # not new content.
+    old_texts_with_glyphs_anywhere = {
+        syl_text
+        for stave_units in current_syllables.values()
+        for syl_text, glyph_ids in stave_units
+        if glyph_ids
+    }
+
     for stave_idx in range(len(staves)):
         neume_glyphs = sorted(glyphs_by_stave.get(stave_idx, []), key=lambda g: g.ulx)
         stave_boxes = boxes_by_stave.get(stave_idx, [])
@@ -1687,18 +1704,22 @@ def verify_and_correct_syllables(
         # which clusters actual existing neume glyphs, so a "-" unit always
         # carries at least one. glyph_ids empty means stave_boxes was
         # non-empty and this specific real syl_box just has no note matched
-        # to it in this stave-scoped, unpooled recheck (a real "text with
-        # nothing under it" box, or a row-mate's box this simplified check
-        # can't see the fragment-pooled glyph match for -- see
-        # _reconstruct_mei_state's docstring: redoing that pooling is out of
-        # scope here). Either way it's real current mothra-text data, not an
-        # invented phantom -- an earlier version of this guard dropped it
-        # outright unless an old unit already had the identical text with
-        # no glyphs, which silently deleted real syllables (and their
-        # boxes) the moment their glyph-matching outcome changed for any
-        # reason, including totally unrelated fixes upstream. Always keep
-        # it; only "-" (which, per above, can't occur here) would need the
-        # anti-regression treatment.
+        # to it in this stave-scoped, unpooled recheck: either a real "text
+        # with nothing under it" box (legitimate, build_mei can produce
+        # these), or a row-mate's fragment-pooled box this simplified check
+        # can't see the glyph match for (see the module-level
+        # old_texts_with_glyphs_anywhere comment above, and
+        # _reconstruct_mei_state's docstring: redoing that pooling is out
+        # of scope here). Distinguish the two by whether this exact text is
+        # already backed by real glyphs somewhere else in the document —
+        # if so it's that duplicate, drop it; otherwise it's genuinely new
+        # data, keep it. An earlier version of this guard instead checked
+        # only THIS stave's own old empty-glyph units, which silently
+        # deleted real new syllables (and their boxes) the moment their
+        # glyph-matching outcome changed for any reason, including
+        # unrelated fixes upstream — too narrow. A version after that
+        # dropped the check entirely, which let the fragment-pooled
+        # duplicate case back in — too broad. This is the middle ground.
         old_units = current_syllables.get(stave_idx, [])
         old_text_by_glyphs = {glyph_ids: syl_text for syl_text, glyph_ids in old_units}
         reconciled_units = []
@@ -1708,6 +1729,8 @@ def verify_and_correct_syllables(
                 old_text = old_text_by_glyphs.get(glyph_ids)
                 if syl_text == "-" and old_text not in (None, "-"):
                     syl_text = old_text
+            elif syl_text in old_texts_with_glyphs_anywhere:
+                continue
             reconciled_units.append((syl_text, box, glyphs_in_syl))
         new_units = reconciled_units
 

--- a/landing-page/scripts/encode_to_mei.py
+++ b/landing-page/scripts/encode_to_mei.py
@@ -323,6 +323,37 @@ def cluster_into_syllables(glyphs: list[Glyph], gap_mult: float = SYLLABLE_GAP_M
             clusters[-1].append(glyph)
     return clusters
 
+def _cluster_boxes_into_rows(boxes: list[dict], gap_mult: float = SYLLABLE_GAP_MULTIPLIER) -> list[list[dict]]:
+    """Group one stave's syl_boxes into physical text rows by Y-gap —
+    mirrors cluster_into_syllables's X-gap clustering, but on the other
+    axis. A single stave's text can legitimately span more than one
+    physical manuscript line: a long line wraps to a continuation row
+    written directly above the next stave begins, still belonging (by
+    this pipeline's manuscript convention, see _assign_boxes_to_staves)
+    to the stave above it rather than the one below. Boxes are sorted by
+    center-Y first so rows come out top-to-bottom; callers must sort each
+    row left-to-right and concatenate rows in this order — never sort two
+    rows' boxes together by X alone, or a wrapped row's leftmost token
+    (written first on the page specifically because it's a continuation)
+    sorts ahead of the row above it whenever it happens to sit further
+    left, scrambling reading order (confirmed: this is exactly the failure
+    _group_staves_by_row's docstring describes for pooled fragments, one
+    axis over)."""
+    if not boxes:
+        return []
+    ordered = sorted(boxes, key=lambda b: (b["ul"][1] + b["lr"][1]) / 2)
+    heights = [b["lr"][1] - b["ul"][1] for b in ordered if b["lr"][1] > b["ul"][1]]
+    threshold = gap_mult * median(heights) if heights else 0
+    rows: list[list[dict]] = [[ordered[0]]]
+    for box in ordered[1:]:
+        prev_cy = (rows[-1][-1]["ul"][1] + rows[-1][-1]["lr"][1]) / 2
+        cy = (box["ul"][1] + box["lr"][1]) / 2
+        if cy - prev_cy > threshold:
+            rows.append([box])
+        else:
+            rows[-1].append(box)
+    return rows
+
 def _assign_boxes_to_staves(staves: list[StaveBbox], boxes: list[dict]) -> dict[int, list[dict]]:
     """Assign each syl_box to a stave — a box strictly inside a stave's
     [uly, lry] band goes there; otherwise it goes to the nearest stave
@@ -337,7 +368,16 @@ def _assign_boxes_to_staves(staves: list[StaveBbox], boxes: list[dict]) -> dict[
     edge. Only a box sitting above every stave (e.g. a rubric before the
     first system) falls back to nearest-by-distance. Every box is placed
     exactly once, deterministically — no 'best single match, everything
-    else dropped' step here."""
+    else dropped' step here.
+
+    Within a stave's bucket, boxes are ordered row-by-row (top to bottom,
+    via _cluster_boxes_into_rows) then left-to-right within each row — NOT
+    by a single flat X sort. A stave whose text wraps to a second physical
+    row (see that helper's docstring) puts both rows' boxes in the same
+    bucket; a flat X sort would interleave the two rows' tokens by raw
+    X-position instead of preserving row order, which is a real observed
+    bug (a wrapped row's continuation syllable sorting ahead of the row
+    above it whenever it happens to sit further left on the page)."""
     result: dict[int, list[dict]] = {i: [] for i in range(len(staves))}
     if not staves:
         return result
@@ -359,8 +399,11 @@ def _assign_boxes_to_staves(staves: list[StaveBbox], boxes: list[dict]) -> dict[
             if dist < best_dist:
                 best_idx, best_dist = idx, dist
         result[best_idx].append(box)
-    for group in result.values():
-        group.sort(key=lambda b: b["ul"][0])
+    for idx, group in result.items():
+        rows = _cluster_boxes_into_rows(group)
+        for row in rows:
+            row.sort(key=lambda b: b["ul"][0])
+        result[idx] = [b for row in rows for b in row]
     return result
 
 def _assign_glyphs_to_boxes(glyphs: list[Glyph], boxes: list[dict]) -> list[list[Glyph]]:
@@ -380,16 +423,33 @@ def _assign_glyphs_to_boxes(glyphs: list[Glyph], boxes: list[dict]) -> list[list
     A glyph whose center falls inside a box's own x-range goes there;
     anything else goes to the nearest box by X-distance. Every glyph lands
     in exactly one box's bucket — some buckets may end up empty (a syllable
-    with no note under it), which is fine; see the caller."""
+    with no note under it), which is fine; see the caller.
+
+    Containment is capped to boxes that aren't extreme width outliers
+    relative to their row-mates (more than 4x the median syl_box width
+    here). A stray/mis-detected syl_box (e.g. a quire mark or page
+    signature mothra-text misreads as a short word) can end up with an
+    anomalously wide X-range; since containment always wins outright over
+    any other box's mere edge-distance, an oversized box's range can swallow
+    every glyph on the whole stave into one syllable, leaving every real
+    syl_box on that stave with none — confirmed as a real observed failure.
+    An outlier-width box still competes for glyphs by ordinary edge-distance,
+    it just loses its automatic containment win; this leaves every
+    normal-width box's behavior (including legitimately wide multi-word
+    boxes) completely unchanged."""
     if not boxes:
         return []
     result: list[list[Glyph]] = [[] for _ in boxes]
+    widths = [b["lr"][0] - b["ul"][0] for b in boxes]
+    typical_width = median(widths) if widths else 0
+    outlier_width = 4 * typical_width if typical_width else float("inf")
     ranges = [(b["ul"][0], b["lr"][0]) for b in boxes]
     for glyph in sorted(glyphs, key=lambda g: g.ulx):
         cx = (glyph.ulx + glyph.lrx) / 2
         best_idx, best_dist = 0, float("inf")
         for i, (lo, hi) in enumerate(ranges):
-            dist = 0 if lo <= cx <= hi else min(abs(cx - lo), abs(cx - hi))
+            contains = lo <= cx <= hi and widths[i] <= outlier_width
+            dist = 0 if contains else min(abs(cx - lo), abs(cx - hi))
             if dist < best_dist:
                 best_idx, best_dist = i, dist
         result[best_idx].append(glyph)
@@ -1238,7 +1298,27 @@ def scale_facsimile(mei_bytes: bytes, factor: float) -> bytes:
                 except (ValueError, TypeError):
                     pass
     return _serialize_mei(root)
-    
+
+def scale_text_alignment(text_alignment: Optional[dict], factor: float) -> Optional[dict]:
+    """Scale a text_alignment's syl_boxes ul/lr coords by factor -- counterpart to
+    scale_facsimile, for when syl_boxes (always computed against the working-copy
+    image) must be compared/written against geometry in a different pixel space."""
+    if not text_alignment or factor == 1.0:
+        return text_alignment
+
+    def _scaled(box):
+        try:
+            ul = [box["ul"][0] * factor, box["ul"][1] * factor]
+            lr = [box["lr"][0] * factor, box["lr"][1] * factor]
+        except (KeyError, TypeError, IndexError):
+            return box  # malformed box passes through unscaled, not dropped
+        return {**box, "ul": ul, "lr": lr}
+
+    scaled = dict(text_alignment)
+    scaled["syl_boxes"] = [_scaled(b) for b in text_alignment.get("syl_boxes", [])]
+    return scaled
+
+
 REQUIRED_MEI_VERSION = "5.0.0-dev"
 
 def validate_mei(xml_bytes: bytes) -> list[str]:
@@ -1601,24 +1681,30 @@ def verify_and_correct_syllables(
         # existing real syl_text for the exact same glyph grouping -- only
         # a genuine glyph-membership change (row split/merge, reordering)
         # or a genuine text change should ever get written.
+        #
+        # NB: a unit with glyph_ids empty is NEVER the "-" fallback --
+        # _build_syllable_units only emits "-" via cluster_into_syllables,
+        # which clusters actual existing neume glyphs, so a "-" unit always
+        # carries at least one. glyph_ids empty means stave_boxes was
+        # non-empty and this specific real syl_box just has no note matched
+        # to it in this stave-scoped, unpooled recheck (a real "text with
+        # nothing under it" box, or a row-mate's box this simplified check
+        # can't see the fragment-pooled glyph match for -- see
+        # _reconstruct_mei_state's docstring: redoing that pooling is out of
+        # scope here). Either way it's real current mothra-text data, not an
+        # invented phantom -- an earlier version of this guard dropped it
+        # outright unless an old unit already had the identical text with
+        # no glyphs, which silently deleted real syllables (and their
+        # boxes) the moment their glyph-matching outcome changed for any
+        # reason, including totally unrelated fixes upstream. Always keep
+        # it; only "-" (which, per above, can't occur here) would need the
+        # anti-regression treatment.
         old_units = current_syllables.get(stave_idx, [])
         old_text_by_glyphs = {glyph_ids: syl_text for syl_text, glyph_ids in old_units}
-        old_empty_texts = {syl_text for syl_text, glyph_ids in old_units if not glyph_ids}
         reconciled_units = []
         for syl_text, box, glyphs_in_syl in new_units:
             glyph_ids = tuple(g.id for g in glyphs_in_syl)
-            if not glyph_ids:
-                # A box with no neumes assigned here is either a genuine
-                # "text with nothing under it" (build_mei can legitimately
-                # produce these for an isolated stave) or -- the same
-                # pooling gap as above -- a box a row-mate actually owns,
-                # miscounted as unclaimed only because pooling isn't
-                # redone here. Only keep it if this stave already had a
-                # matching empty-glyph unit; otherwise it's a phantom this
-                # unpooled recheck invents, not a real disagreement.
-                if syl_text not in old_empty_texts:
-                    continue
-            else:
+            if glyph_ids:
                 old_text = old_text_by_glyphs.get(glyph_ids)
                 if syl_text == "-" and old_text not in (None, "-"):
                     syl_text = old_text

--- a/landing-page/scripts/mei_api.py
+++ b/landing-page/scripts/mei_api.py
@@ -166,8 +166,16 @@ def create_edit_session(project_id: int, mei_id: str, user=Depends(get_current_u
                 dims = encode_to_mei.image_dimensions(image_bytes) if text_alignment else None
                 if dims:
                     image_w, image_h = dims
+                    # image_bytes/dims may be original_data (pre-upload-resize) while text_alignment's
+                    # syl_boxes were always computed against the working copy (img_data) -- see
+                    # text_api.py's _project_image. Rescale before comparing/writing zones against
+                    # image_w/image_h. Degrades to factor=1.0 (today's behavior) if the working copy's
+                    # header can't be read -- image_dimensions returns None rather than raising.
+                    working_dims = encode_to_mei.image_dimensions(bytes(img_data)) if img_data is not None else None
+                    factor = (image_w / working_dims[0]) if working_dims and working_dims[0] else 1.0
+                    scaled_alignment = encode_to_mei.scale_text_alignment(text_alignment, factor)
                     corrected_bytes, correction_logs = encode_to_mei.verify_and_correct_syllables(
-                        xml_content.encode(), text_alignment, image_w, image_h,
+                        xml_content.encode(), scaled_alignment, image_w, image_h,
                     )
                     if correction_logs:
                         xml_content = corrected_bytes.decode()

--- a/landing-page/scripts/mei_api.py
+++ b/landing-page/scripts/mei_api.py
@@ -169,11 +169,15 @@ def create_edit_session(project_id: int, mei_id: str, user=Depends(get_current_u
                     # image_bytes/dims may be original_data (pre-upload-resize) while text_alignment's
                     # syl_boxes were always computed against the working copy (img_data) -- see
                     # text_api.py's _project_image. Rescale before comparing/writing zones against
-                    # image_w/image_h. Degrades to factor=1.0 (today's behavior) if the working copy's
-                    # header can't be read -- image_dimensions returns None rather than raising.
+                    # image_w/image_h. Degrades to factor=1.0 on both axes (today's behavior) if the
+                    # working copy's header can't be read -- image_dimensions returns None rather
+                    # than raising. X and Y factors are computed independently, not from one shared
+                    # ratio -- imageResize.ts rounds width/height separately after one scalar shrink,
+                    # so the two axes' ratios can differ slightly even for a visually uniform resize.
                     working_dims = encode_to_mei.image_dimensions(bytes(img_data)) if img_data is not None else None
-                    factor = (image_w / working_dims[0]) if working_dims and working_dims[0] else 1.0
-                    scaled_alignment = encode_to_mei.scale_text_alignment(text_alignment, factor)
+                    factor_x = (image_w / working_dims[0]) if working_dims and working_dims[0] else 1.0
+                    factor_y = (image_h / working_dims[1]) if working_dims and working_dims[1] else 1.0
+                    scaled_alignment = encode_to_mei.scale_text_alignment(text_alignment, factor_x, factor_y)
                     corrected_bytes, correction_logs = encode_to_mei.verify_and_correct_syllables(
                         xml_content.encode(), scaled_alignment, image_w, image_h,
                     )

--- a/landing-page/scripts/staffline_stage.py
+++ b/landing-page/scripts/staffline_stage.py
@@ -269,8 +269,9 @@ def _run_fallback_redetect_stage(
         if job_id is not None:
             check_cancelled(job_id)
 
-        y0, y1 = int(region.y_start), int(region.y_end)
-        x0, x1 = int(region.x_start), int(region.x_end)
+        page_h, page_w = image_arr.shape[:2]
+        y0, y1 = max(0, int(region.y_start)), min(page_h, int(region.y_end))
+        x0, x1 = max(0, int(region.x_start)), min(page_w, int(region.x_end))
         probe_crop = image_arr[y0:y1, x0:x1]
         if probe_crop.size == 0:
             trace.append(f"[trace] {image_name}: stave {region.stave_id} fallback probe crop degenerate; skipping")
@@ -305,15 +306,24 @@ def _run_fallback_redetect_stage(
 
         for candidate in accepted:
             fit_result = candidate.fit
-            fit_result.flags = list(fit_result.flags) + [
-                "fallback_redetected", f"fallback_conf:{candidate.yolo_confidence:.3f}",
+            fit_result.flags = [
+                *fit_result.flags, "fallback_redetected", f"fallback_conf:{candidate.yolo_confidence:.3f}",
             ]
             fit_results.append(fit_result)
+            # y_values are crop-local (see FitResult's docstring); the box's
+            # vertical extent must come from their page-space min/max, not a
+            # fixed 1px placeholder -- StafflineViewerModal.tsx strokeRect's
+            # this directly, and staffline_adapter.py folds it into stave
+            # bounds, so a degenerate box there visibly under-draws/mis-sizes
+            # a recovered line.
+            page_ys = [y + fit_result.y_page_offset for y in fit_result.y_values]
+            uly = min(page_ys) if page_ys else fit_result.y_page_offset
+            lry = max(page_ys) if page_ys else fit_result.y_page_offset
             boxes.append((
                 int(fit_result.x_page_offset),
-                int(fit_result.y_page_offset),
+                int(uly),
                 int(fit_result.x_page_offset + (fit_result.x_end - fit_result.x_start)),
-                int(fit_result.y_page_offset + 1),  # height not tracked post-fit; not load-bearing downstream
+                int(lry) + 1,  # +1 so lry > uly even for a perfectly flat fit
             ))
             n_added += 1
     return n_added, trace

--- a/landing-page/scripts/staffline_stage.py
+++ b/landing-page/scripts/staffline_stage.py
@@ -26,7 +26,7 @@ like a stream_text_finding failure would.
 
 import json
 import uuid as _uuid
-from typing import Iterator, Optional
+from typing import Callable, Iterator, Optional
 
 import numpy as np
 
@@ -39,6 +39,14 @@ STAFFLINE_CLASS_ID = 2
 
 # Matches staff-finding/scripts/run_page.py's DEFAULT_CROP_PADDING_PX.
 CROP_PADDING_PX = 2
+
+# Fallback missed-detection re-probe (medieval-preset only; see
+# _run_fallback_redetect_stage). Ported verbatim from
+# staff-finding/scripts/run_page.py's DEFAULT_FALLBACK_CONF/_IOU/FALLBACK_IMGSZ
+# -- that module can't be imported directly; see this file's module docstring.
+FALLBACK_CONF = 0.15
+FALLBACK_IOU = 0.7
+FALLBACK_IMGSZ = 1280
 
 
 def has_class(yolo_txt: str, class_id: int) -> bool:
@@ -180,10 +188,140 @@ def _assemble_jsomr_records(image_name, fit_results, boxes, grouping_result, sca
     ))
     return records
 
+def _sibling_widths_for_stave(stave_id, grouping_result, fit_results) -> list[float]:
+    """Page-absolute x-widths of a stave's own already-detected fits, for
+    fallback_redetect.is_plausible_width's relative-width comparison. Ported
+    verbatim from staff-finding/scripts/run_page.py's
+    _sibling_widths_for_stave (that module can't be imported directly; see
+    this file's module docstring)."""
+    from group_staves import page_absolute_x_range
+
+    widths = []
+    for asg in grouping_result.assignments:
+        if asg.stave_id != stave_id:
+            continue
+        rng = page_absolute_x_range(fit_results[asg.fit_index])
+        if rng is not None:
+            widths.append(rng[1] - rng[0])
+    return widths
+
+def _top_score_of(result) -> Optional[float]:
+    """Pull the kept component's total score from a ComponentFilterResult.
+    Ported verbatim from staff-finding/scripts/run_page.py's _top_score_of
+    (that module can't be imported directly; see this file's module
+    docstring)."""
+    for entry in result.score_breakdown.values():
+        if entry.get("kept"):
+            return float(entry["total"])
+    return None
+
+def _run_fallback_redetect_stage(
+    image_name: str, image_arr: np.ndarray, w: int,
+    fit_results: list, boxes: list, grouping_result,
+    scale_unit: float, redetect_fn: Callable, job_id: Optional[str] = None,
+) -> tuple[int, list[str]]:
+    """Probe under-populated staves for stave-class boxes the primary YOLO
+    pass missed entirely -- confirmed, on real pages, to happen even for
+    perfectly ordinary, well-inked staves. Mutates fit_results/boxes in
+    place, appending one entry per accepted candidate, in lockstep (both
+    lists are always the same length -- _assemble_jsomr_records zips them),
+    so the caller's second group_staves() call and _assemble_jsomr_records
+    need no special-casing for these entries.
+
+    Mirrors staff-finding/scripts/run_page.py's own run_fallback_redetect()
+    (that module can't be imported directly; see this file's module
+    docstring), using redetect_fn (YoloModelSet.infer_staves_raw_boxes, bound
+    to the already-loaded medieval stave model) in place of a directly-
+    loaded ultralytics.YOLO model -- the whole reason this wasn't wired up
+    before now (custom/uploaded models have no dedicated stave-only model
+    instance to reuse for a second pass; see CLAUDE.md).
+
+    Returns (n_added, trace) -- trace is a list of already-formatted
+    "[trace] ..." log message strings, matching _fit_and_group's own trace
+    list shape so run_staffline_detection can yield them identically.
+    """
+    from component_filter import filter_components
+    from fit_centerline import fit_centerline
+    from fallback_redetect import FallbackCandidate, identify_probe_regions, validate_and_select_candidates
+
+    trace: list[str] = []
+    if grouping_result.mode_lines_per_stave is None:
+        trace.append(f"[trace] {image_name}: fallback re-probe skipped (no page-level mode line count)")
+        return 0, trace
+
+    regions = identify_probe_regions(
+        fits=fit_results,
+        assignments=grouping_result.assignments,
+        rhythm_anomalies=grouping_result.rhythm_anomalies,
+        gap_distribution=grouping_result.gap_distribution,
+        scale_unit=scale_unit,
+        min_threshold=grouping_result.min_threshold_px,
+        cut_threshold=grouping_result.cut_threshold_px,
+        mode_n=grouping_result.mode_lines_per_stave,
+        page_width=w,
+    )
+    if not regions:
+        trace.append(f"[trace] {image_name}: fallback re-probe found no under-populated staves; nothing to probe")
+        return 0, trace
+
+    n_added = 0
+    for region in regions:
+        if job_id is not None:
+            check_cancelled(job_id)
+
+        y0, y1 = int(region.y_start), int(region.y_end)
+        x0, x1 = int(region.x_start), int(region.x_end)
+        probe_crop = image_arr[y0:y1, x0:x1]
+        if probe_crop.size == 0:
+            trace.append(f"[trace] {image_name}: stave {region.stave_id} fallback probe crop degenerate; skipping")
+            continue
+        raw_boxes = redetect_fn(probe_crop, FALLBACK_CONF, FALLBACK_IOU, FALLBACK_IMGSZ)
+
+        candidates: list[FallbackCandidate] = []
+        for raw_box in raw_boxes:
+            bx0, by0, bx1, by1 = raw_box["xyxy"]
+            page_box = (
+                int(round(bx0)) + x0, int(round(by0)) + y0,
+                int(round(bx1)) + x0, int(round(by1)) + y0,
+            )
+            crop, actual_box = _crop_with_padding(image_arr, page_box, CROP_PADDING_PX)
+            if crop.size == 0:
+                continue
+            filter_result = filter_components(crop, scale_unit=scale_unit)
+            fit_result = fit_centerline(filter_result, scale_unit=scale_unit)
+            fit_result.x_page_offset = float(actual_box[0])
+            fit_result.y_page_offset = float(actual_box[1])
+            stage1_score = _top_score_of(filter_result) or 0.0
+            candidates.append(FallbackCandidate(
+                fit=fit_result, yolo_confidence=raw_box["confidence"], stage1_score=stage1_score,
+            ))
+        sibling_widths = _sibling_widths_for_stave(region.stave_id, grouping_result, fit_results)
+        accepted, cap_exceeded = validate_and_select_candidates(region, candidates, sibling_widths)
+        trace.append(
+            f"[trace] {image_name}: stave {region.stave_id} fallback re-probe: "
+            f"{len(candidates)} candidate(s) found, {len(accepted)} accepted"
+            + (f", cap_exceeded (fallback_found_more_than_expected:{region.stave_id})" if cap_exceeded else "")
+        )
+
+        for candidate in accepted:
+            fit_result = candidate.fit
+            fit_result.flags = list(fit_result.flags) + [
+                "fallback_redetected", f"fallback_conf:{candidate.yolo_confidence:.3f}",
+            ]
+            fit_results.append(fit_result)
+            boxes.append((
+                int(fit_result.x_page_offset),
+                int(fit_result.y_page_offset),
+                int(fit_result.x_page_offset + (fit_result.x_end - fit_result.x_start)),
+                int(fit_result.y_page_offset + 1),  # height not tracked post-fit; not load-bearing downstream
+            ))
+            n_added += 1
+    return n_added, trace
 
 def _fit_and_group(
     image_name: str, image_arr: np.ndarray, w: int, h: int, detections, scale_unit: float,
     interpolate_missing: bool, job_id: Optional[str] = None,
+    redetect_fn: Optional[Callable] = None,
 ) -> dict:
     """Per-box centerline fit + stave grouping -- shared by
     run_staffline_detection (persisted, tied to a Celery job) and
@@ -194,6 +332,14 @@ def _fit_and_group(
     call only runs once per image; a page with many stave boxes can spend
     real time in this loop with no cancellation observed in between).
     Omit it for the preview path, which has no job to cancel.
+
+    redetect_fn, if given, is called as redetect_fn(crop, conf, iou, imgsz)
+    for each under-populated stave's probe region and must return
+    list[{"xyxy": (x0,y0,x1,y1), "confidence": float}] in the crop's own
+    local coordinates (see YoloModelSet.infer_staves_raw_boxes). Omit it
+    (default None) to skip the fallback re-probe entirely -- the only
+    caller passing a real one today is tasks_predict.py, and only for the
+    medieval preset (see module CLAUDE.md's Staffline detection section).
 
     Returns a dict with "trace" (already-formatted [trace] message strings,
     so both callers report identical box-count tracing) always present, and
@@ -231,11 +377,28 @@ def _fit_and_group(
     grouping_result = group_staves(
         fit_results, scale_unit=scale_unit, interpolate_missing=interpolate_missing,
     )
+
+    fallback_lines_added = 0
+    if redetect_fn is not None:
+        fallback_lines_added, fallback_trace = _run_fallback_redetect_stage(
+            image_name, image_arr, w, fit_results, boxes, grouping_result,
+            scale_unit, redetect_fn, job_id=job_id,
+        )
+        trace.extend(fallback_trace)
+        if fallback_lines_added:
+            grouping_result = group_staves(
+                fit_results, scale_unit=scale_unit, interpolate_missing=interpolate_missing,
+            )
+            trace.append(
+                f"[trace] {image_name}: fallback re-probe recovered {fallback_lines_added} "
+                f"line(s); stave grouping re-run"
+            )
     records = _assemble_jsomr_records(image_name, fit_results, boxes, grouping_result, scale_unit)
     stave_ids = {r["stave_id"] for r in records if r["stave_id"] is not None}
     return {
         "degenerate": False, "trace": trace,
         "records": records, "stave_ids": stave_ids, "grouping_result": grouping_result,
+        "fallback_lines_added": fallback_lines_added,
     }
 
 
@@ -341,6 +504,7 @@ def run_staffline_detection(
     project_id: int, image_id: str, image_name: str, annotation_id: str,
     image_arr: np.ndarray, yolo_txt: str,
     interpolate_missing: bool = False,
+    redetect_fn: Optional[Callable] = None,
 ) -> Iterator[dict]:
     """Run staffline detection for one image, yielding {"type": "log"|"error",
     "message": ...} event dicts and persisting the result to
@@ -357,6 +521,11 @@ def run_staffline_detection(
     except below -- a cancelled job must actually stop, not be recorded as
     one failed staffline-detection attempt among many while the outer
     per-image loop keeps going.
+
+    redetect_fn is passed straight through to _fit_and_group -- see that
+    function's docstring. Default None (no fallback re-probe) keeps every
+    existing caller's behavior unchanged; tasks_predict.py is the only
+    caller that passes a real one, and only for the medieval preset.
     """
     from yolo_io import parse_yolo_lines, filter_to_class
 
@@ -374,7 +543,8 @@ def run_staffline_detection(
     scale_unit = _compute_page_scale_unit(detections, w, h)
 
     try:
-        result = _fit_and_group(image_name, image_arr, w, h, detections, scale_unit, interpolate_missing, job_id=job_id)
+        result = _fit_and_group(image_name, image_arr, w, h, detections, scale_unit, interpolate_missing, job_id=job_id,
+                        redetect_fn=redetect_fn, )
         for msg in result["trace"]:
             yield {"type": "log", "message": msg}
 
@@ -391,7 +561,9 @@ def run_staffline_detection(
         settings = {
             "interpolate_missing": interpolate_missing,
             "binarization": "sauvola",
-            "bgr_enabled": False,  # ink-separation deferred this pass, see module docstring
+            "bgr_enabled": False,
+            "fallback_redetect_enabled": redetect_fn is not None,
+            "fallback_lines_added": result.get("fallback_lines_added", 0),
             "package_version": _package_version(),
         }
 

--- a/landing-page/scripts/tasks_predict.py
+++ b/landing-page/scripts/tasks_predict.py
@@ -282,8 +282,13 @@ def run_predict_task(job_id, project_id, body):
                 publish({"type": "log", "message":
                     f"[trace] {image_name}: stave-class boxes came from model"
                     f" '{yolo_models.model_label}' (hash {yolo_models.model_hash or 'n/a'})"})
+                redetect_fn = (
+                    yolo_models.infer_staves_raw_boxes
+                    if yolo_models.medieval_models is not None else None
+                )
                 for sf_ev in run_staffline_detection(
                     job_id, cur, con, project_id, image_id, image_name, ann_id, staffline_source_arr, yolo_txt,
+                    redetect_fn=redetect_fn,
                 ):
                     if sf_ev.get("type") == "error":
                         publish({"type": "log", "message": f"staffline-detection: {sf_ev.get('message', 'failed')}"})

--- a/landing-page/scripts/tasks_predict.py
+++ b/landing-page/scripts/tasks_predict.py
@@ -126,6 +126,32 @@ def _run_medieval_inference(yolo_models, img_arr, image_bytes, mime_type, image_
 
     return "\n".join(filter(None, [tm_txt, st_txt])), source_arr
 
+
+def _reused_annotation_staffline_source(img_arr, image_bytes, mime_type, image_name, publish):
+    """The classifier-regeneration half of _run_medieval_inference's stave
+    pipeline, reused for a has_annotation=True (reused) image under the
+    medieval preset -- see that function's docstring and the call site
+    above for why the raw page is the wrong default source here. Runs
+    synchronously (no concurrent YOLO pass to overlap with, unlike the
+    fresh-run path) and falls back to the raw page on any classifier
+    failure, matching _run_medieval_inference's own fallback exactly."""
+    import cv2
+    import numpy as np
+    try:
+        stafflines_png, _background_png = classify_stafflines(image_bytes, mime_type)
+        arr = cv2.imdecode(np.frombuffer(stafflines_png, np.uint8), cv2.IMREAD_COLOR)
+        if arr is None:
+            raise PacoClassifierError("could not decode stafflines PNG from paco-classifier-service")
+        if arr.shape[:2] != img_arr.shape[:2]:
+            raise PacoClassifierError(f"classifier output {arr.shape[:2]} != page {img_arr.shape[:2]}")
+        return arr
+    except Exception as e:
+        publish({
+            "type": "log",
+            "message": f"{image_name}: staffline classifier unavailable ({e}) — falling back to raw-image stave detection",
+        })
+        return img_arr
+
 @celery_app.task(name="predict.run")
 def run_predict_task(job_id, project_id, body):
     """Celery task backing `POST /api/projects/{id}/predict`.
@@ -269,7 +295,24 @@ def run_predict_task(job_id, project_id, body):
                     "jsonName": "", "detectionCount": n_detections,
                 })
             else:
-                staffline_source_arr = img_arr  # reused annotation -- no fresh classifier run to redo
+                if yolo_models.medieval_models is not None:
+                    # A reused annotation's stave-box coordinates carry no
+                    # record of which image they were actually detected
+                    # against -- if they came from an earlier medieval-preset
+                    # run, that was the paco-classifier's stafflines-only
+                    # layer, not the raw page (see _run_medieval_inference).
+                    # Defaulting to the raw page here would crop staffline
+                    # detection from different pixels than produced these
+                    # boxes. Regenerate that layer unconditionally rather
+                    # than guess the boxes' provenance -- classifying is
+                    # never worse than the raw page for Sauvola-binarization-
+                    # based line detection, whichever source the existing
+                    # boxes actually came from.
+                    staffline_source_arr = _reused_annotation_staffline_source(
+                        img_arr, bytes(image_data), mime_type, image_name, publish,
+                    )
+                else:
+                    staffline_source_arr = img_arr  # non-medieval preset -- boxes were always raw-page-sourced
 
             # Staffline detection is gated only on has_class (fresh stave-class
             # boxes to work from), never on has_text_alignment -- an image can

--- a/landing-page/scripts/yolo_inference.py
+++ b/landing-page/scripts/yolo_inference.py
@@ -103,6 +103,42 @@ class YoloModelSet:
         _append_boxes(lines, st_model(img_arr, device=self.st_device, verbose=False)[0], st_map, self.st_threshold)
         return "\n".join(lines)
 
+    def infer_staves_raw_boxes(self, img_arr, conf: float, iou: float, imgsz: int) -> list[dict]:
+        """Medieval-preset-only: run the stave detector directly on `img_arr`
+        (typically a small page crop, not the full page) at caller-chosen
+        conf/iou/imgsz, returning raw crop-local pixel boxes plus each box's
+        own confidence -- unlike infer_staves(), this bypasses the yolo-txt
+        round trip and self.st_threshold entirely, since staffline_stage.py's
+        fallback re-probe (_run_fallback_redetect_stage) needs per-box
+        confidence values to rank candidates
+        (fallback_redetect.validate_and_select_candidates), not a
+        fixed-threshold yolo-txt line. Mirrors
+        staff-finding/scripts/run_page.py's own run_fallback_redetect()
+        model.predict(...) call exactly, so an equivalent standalone CLI run
+        and this in-process path behave identically.
+
+        Returns one dict per surviving box: {"xyxy": (x0, y0, x1, y1),
+        "confidence": float}, crop-local (same coordinate frame as img_arr)
+        -- the caller converts to page-absolute using its own crop origin,
+        exactly like it already does for the page's primary stave-class
+        boxes.
+        """
+        assert self.medieval_models is not None, "infer_staves_raw_boxes is medieval-preset-only"
+        _, st_model = self.medieval_models
+        _, st_map = self.class_maps
+        result = st_model.predict(
+            source=img_arr, conf=conf, iou=iou, imgsz=imgsz, save=False, verbose=False,
+        )[0]
+        boxes = []
+        if result.boxes is not None:
+            for box in result.boxes:
+                if st_map.get(int(box.cls[0])) is None:
+                    continue
+                x0, y0, x1, y1 = box.xyxy[0].tolist()
+                boxes.append({"xyxy": (x0, y0, x1, y1), "confidence": float(box.conf[0])})
+        return boxes
+
+
 def resolve_yolo_models(
         cur, project_id: int, model_preset: str, model_id: Optional[str],
         confidence_threshold: float, device: str,

--- a/landing-page/scripts/yolo_inference.py
+++ b/landing-page/scripts/yolo_inference.py
@@ -127,7 +127,7 @@ class YoloModelSet:
         _, st_model = self.medieval_models
         _, st_map = self.class_maps
         result = st_model.predict(
-            source=img_arr, conf=conf, iou=iou, imgsz=imgsz, save=False, verbose=False,
+            source=img_arr, conf=conf, iou=iou, imgsz=imgsz, device=self.st_device, save=False, verbose=False,
         )[0]
         boxes = []
         if result.boxes is not None:


### PR DESCRIPTION
refs: #184, #182

- text boxes now resize when an image was resized (for staff) and then resized to original dimensions (for neon)
- prevented edge case of syllables skipping around lines
- text_batch job failing due to submodule issues when merging paco branch; bumping submodule to hopefully resolve it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stave and glyph assignment to reduce misplaced musical and lyric content.
  * Improved handling of text alignment across image sizes for more accurate syllable placement.
  * Preserved text boxes when matching information is incomplete.
  * Retained text-only staves during MEI generation.

* **Improvements**
  * Added fallback stave detection to recover missed staff lines in supported processing scenarios.
  * Improved ordering of text rows and stave processing for more consistent output.
  * Improved handling of unusually wide text regions and malformed alignment data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->