### PR TITLE
Fix IC step dead ends and move saved-session resume out of the modal

### DIFF
--- a/landing-page/scripts/ic_api.py
+++ b/landing-page/scripts/ic_api.py
@@ -331,6 +331,37 @@ def ic_manage_url(project_id: int, user=Depends(get_current_user)) -> dict:
     }
 
 
+@router.get("/projects/{project_id}/ic/session-count")
+def ic_session_count(project_id: int, user=Depends(get_current_user)) -> dict:
+    """How many saved IC sessions this project has.
+
+    Sessions live in IC's store, not mothra's DB, so whether a project has any
+    is not derivable here — the project page needs this to decide whether to
+    offer "manage IC sessions". It can't key that off ``steps_unlocked``:
+    sessions can exist while that is still 0 (the ``VITE_SKIP_PREDICT`` dev
+    path goes straight to IC, and a batch text-finding job that fails after
+    its YOLO stage leaves annotations behind without advancing the step), and
+    those are exactly the cases where a stale session most needs clearing.
+
+    Errors are the caller's to interpret rather than something to swallow into
+    a 0 here — a count of zero and "IC is down" must stay distinguishable, or
+    an unreachable IC would silently hide the button again.
+    """
+    with db_cursor() as (con, cur):
+        require_project_owner(cur, project_id, user["id"])
+    try:
+        # Short timeout on purpose: this runs on every project-page open, and
+        # a down IC must not park a request thread on the default 30s.
+        _, raw = _get(f"{IC_API_URL}/sessions?project_id={project_id}", timeout=5)
+    except urllib.error.URLError as exc:
+        raise _ic_unreachable(exc)
+    try:
+        sessions = json.loads(raw)
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=502, detail="IC returned a malformed session list")
+    return {"count": len(sessions) if isinstance(sessions, list) else 0}
+
+
 # ---------------------------------------------------------------------------
 # Batch training set + "queue all" (parent-page-driven, no per-page iframe)
 # ---------------------------------------------------------------------------

--- a/landing-page/scripts/ic_api.py
+++ b/landing-page/scripts/ic_api.py
@@ -359,7 +359,12 @@ def ic_session_count(project_id: int, user=Depends(get_current_user)) -> dict:
         sessions = json.loads(raw)
     except json.JSONDecodeError:
         raise HTTPException(status_code=502, detail="IC returned a malformed session list")
-    return {"count": len(sessions) if isinstance(sessions, list) else 0}
+    if not isinstance(sessions, list):
+        raise HTTPException(
+            status_code=502,
+            detail="IC returned a malformed session list",
+        )
+    return {"count": len(sessions)}
 
 
 # ---------------------------------------------------------------------------

--- a/landing-page/src/components/AppRouter.tsx
+++ b/landing-page/src/components/AppRouter.tsx
@@ -9,7 +9,7 @@ import type {
 } from "../types";
 import type { CurrentUser } from "../hooks/useAuth";
 import { apiFetch, apiFetchOrThrow, apiFetchJobStream } from "../lib/apiFetch";
-import { getImageProgress, minNextStep } from "../utils/imageStep";
+import { minNextStep, pendingIcImages } from "../utils/imageStep";
 import { downloadBlob } from "../utils/download";
 import type { useProjectMutations } from "../hooks/useProjectMutations";
 import { useInferenceSettings } from "../hooks/useInferenceSettings";
@@ -20,6 +20,7 @@ import AuthPage from "./auth/AuthPage";
 import MyAccount from "./account/MyAccount";
 import MyProjects from "./project/MyProjects";
 import ProjectDetail from "./project/ProjectDetail";
+import type { IcResumeRequest } from "./project/IcSessionsModal";
 import ProcessingPage from "./workflow/ProcessingPage";
 import CompletionPage from "./workflow/CompletionPage";
 import InteractiveClassifier from "./workflow/InteractiveClassifier";
@@ -177,6 +178,12 @@ export default function AppRouter({
   const [clefShape, setClefShape] = useState<"C" | "F">("C");
   const [clefLine, setClefLine] = useState(3);
 
+  // A saved IC session picked in the project page's "manage IC sessions"
+  // modal, to be opened on the IC step page. Cleared by goToIc() below, so
+  // every other route into that view starts on the first page to classify.
+  const [resumeIcSession, setResumeIcSession] =
+    useState<IcResumeRequest | null>(null);
+
   const [sendingBundle, setSendingBundle] = useState(false);
   const [sendBundleError, setSendBundleError] = useState<string | null>(null);
 
@@ -223,6 +230,16 @@ export default function AppRouter({
     ];
     if (PROJECT_VIEWS.includes(view) && !selectedProject) setView("projects");
   }, [view, selectedProject]);
+
+  // Ordinary way into the IC step: start on the first page to classify. Any
+  // saved-session resume left over from a previous visit is dropped here, so
+  // only the "manage IC sessions" path (which sets it) ever opens one - the
+  // request has to outlive the navigation itself, since the "ic" case below
+  // keeps reading it to hold the session's page in the filmstrip.
+  const goToIc = () => {
+    setResumeIcSession(null);
+    setView("ic");
+  };
 
   switch (view) {
     case "landing":
@@ -284,7 +301,7 @@ export default function AppRouter({
             );
             if (step >= 4) handleSendToCantus();
             else if (step >= 3) setView("neon-editor");
-            else if (step >= 1 || SKIP_PREDICT) setView("ic");
+            else if (step >= 1 || SKIP_PREDICT) goToIc();
             else {
               setBatchRunIds(computeBatchRun(selectedProject));
               setBatchResult(null);
@@ -299,15 +316,19 @@ export default function AppRouter({
           onStepClick={(step) => {
             if (step === 0) {
               if (SKIP_PREDICT) {
-                setView("ic");
+                goToIc();
                 return;
               }
               setBatchRunIds(computeBatchRun(selectedProject));
               setBatchResult(null);
               setView("processing");
-            } else if (step === 1) setView("ic");
+            } else if (step === 1) goToIc();
             else if (step === 2) setView("ic-completion");
             else if (step === 3) setView("neon-editor");
+          }}
+          onResumeIcSession={(req) => {
+            setResumeIcSession(req);
+            setView("ic");
           }}
           onSendToCantus={handleSendToCantus}
           sendingBundle={sendingBundle}
@@ -637,7 +658,7 @@ export default function AppRouter({
     case "completion":
       return (
         <CompletionPage
-          onContinue={() => setView("ic")}
+          onContinue={() => goToIc()}
           onBackToProject={() => setView("project")}
           logsFileName="annotatorlogs.txt"
           logContent={annotationLogs.join("\n")}
@@ -698,36 +719,42 @@ export default function AppRouter({
           }
         />
       );
-    case "ic":
-      return selectedProject ? (
+    case "ic": {
+      if (!selectedProject) return null;
+      const pending = pendingIcImages(
+        selectedProject.images,
+        selectedProject.usedImageNames,
+        selectedProject.annotations ?? [],
+        selectedProject.meiFiles ?? [],
+        selectedProject.stepsUnlocked,
+      );
+      // The page a resume request (from "manage IC sessions") points at. IC
+      // records mothra's image id when the session is staged; fall back to the
+      // file-name stem it also stores, for sessions saved without one.
+      const resumeImage = resumeIcSession
+        ? (selectedProject.images.find(
+            (img) => img.id === resumeIcSession.imageId,
+          ) ??
+          selectedProject.images.find(
+            (img) =>
+              img.name.replace(/\.[^.]+$/, "") === resumeIcSession.sourceName,
+          ) ??
+          null)
+        : null;
+      // A saved session's page is normally still pending, but it doesn't have
+      // to be (its page may have been encoded by some other route). Add it
+      // back rather than silently ignoring the click - and so the queued XML
+      // is paired with the right image, which needs the page to be selectable.
+      const images =
+        resumeImage && !pending.some((img) => img.id === resumeImage.id)
+          ? [...pending, resumeImage]
+          : pending;
+      return (
         <InteractiveClassifier
-          images={selectedProject.images
-            .filter((img) => {
-              if (!selectedProject.usedImageNames.includes(img.name))
-                return false;
-              const p = getImageProgress(
-                img.name,
-                selectedProject.annotations ?? [],
-                selectedProject.meiFiles ?? [],
-                selectedProject.stepsUnlocked,
-              );
-              return p === null || p.nextStep <= 1;
-            })
-            .sort((a, b) => {
-              const pa = getImageProgress(
-                a.name,
-                selectedProject.annotations ?? [],
-                selectedProject.meiFiles ?? [],
-                selectedProject.stepsUnlocked,
-              );
-              const pb = getImageProgress(
-                b.name,
-                selectedProject.annotations ?? [],
-                selectedProject.meiFiles ?? [],
-                selectedProject.stepsUnlocked,
-              );
-              return (pa?.nextStep ?? 0) - (pb?.nextStep ?? 0);
-            })}
+          images={images}
+          initialImageName={resumeImage?.name ?? null}
+          usedImageCount={selectedProject.usedImageNames.length}
+          onBack={() => setView("project")}
           projectId={selectedProjectId}
           clefShape={clefShape}
           onClefShapeChange={setClefShape}
@@ -745,7 +772,8 @@ export default function AppRouter({
             setView("encoding-processing");
           }}
         />
-      ) : null;
+      );
+    }
     case "ic-completion":
       return (
         <IcCompletionTestPage
@@ -763,7 +791,7 @@ export default function AppRouter({
           <ProcessingPage
             {...STEP_TIMING}
             logs={encodingLogs}
-            onBack={() => setView("ic")}
+            onBack={() => goToIc()}
             onComplete={() => {
               if (selectedProjectId && selectedProject) {
                 updateProjectSteps(
@@ -811,7 +839,7 @@ export default function AppRouter({
             pendingImageFile ? `encoding ${pendingImageFile.name}` : "encoding"
           }
           logs={encodingLogs}
-          onBack={() => setView("ic")}
+          onBack={() => goToIc()}
           onComplete={() => {
             if (selectedProjectId && selectedProject) {
               updateProjectSteps(
@@ -847,17 +875,15 @@ export default function AppRouter({
       ) : null;
     }
     case "encoding-completion": {
-      const remainingIcImages =
-        selectedProject?.images.filter((img) => {
-          if (!selectedProject.usedImageNames.includes(img.name)) return false;
-          const p = getImageProgress(
-            img.name,
+      const remainingIcImages = selectedProject
+        ? pendingIcImages(
+            selectedProject.images,
+            selectedProject.usedImageNames,
             selectedProject.annotations ?? [],
             selectedProject.meiFiles ?? [],
             selectedProject.stepsUnlocked,
-          );
-          return p === null || p.nextStep <= 1;
-        }) ?? [];
+          )
+        : [];
 
       const batchDescription = batchSummary
         ? `batch encoding complete: ${batchSummary.succeeded.length} succeeded${
@@ -883,7 +909,7 @@ export default function AppRouter({
           onDownloadMei={meiContent ? handleDownloadMei : undefined}
           onDownloadManifest={meiContent ? handleDownloadManifest : undefined}
           onClassifyMore={
-            remainingIcImages.length > 0 ? () => setView("ic") : undefined
+            remainingIcImages.length > 0 ? () => goToIc() : undefined
           }
           classifyMoreCount={
             remainingIcImages.length > 0 ? remainingIcImages.length : undefined

--- a/landing-page/src/components/AppRouter.tsx
+++ b/landing-page/src/components/AppRouter.tsx
@@ -24,6 +24,7 @@ import type { IcResumeRequest } from "./project/IcSessionsModal";
 import ProcessingPage from "./workflow/ProcessingPage";
 import CompletionPage from "./workflow/CompletionPage";
 import InteractiveClassifier from "./workflow/InteractiveClassifier";
+import IcSessionUnavailable from "./workflow/IcSessionUnavailable";
 import IcCompletionTestPage from "./workflow/ICCompletionTestPage";
 import NeonCompletionPage from "./workflow/NeonCompletionPage";
 import NeonBatchEditor from "./workflow/NeonBatchEditor";
@@ -729,18 +730,35 @@ export default function AppRouter({
         selectedProject.stepsUnlocked,
       );
       // The page a resume request (from "manage IC sessions") points at. IC
-      // records mothra's image id when the session is staged; fall back to the
-      // file-name stem it also stores, for sessions saved without one.
+      // records mothra's image id when the session is staged, so that's the
+      // authoritative match; the file-name stem it also stores is a fallback
+      // only for sessions saved without an id. Deliberately not a fallback for
+      // an id that fails to resolve - that means the page was deleted, and a
+      // stem match could land on a different image that reuses the filename
+      // (the session wouldn't even be the one /ic/start finds for it).
       const resumeImage = resumeIcSession
-        ? (selectedProject.images.find(
-            (img) => img.id === resumeIcSession.imageId,
-          ) ??
-          selectedProject.images.find(
-            (img) =>
-              img.name.replace(/\.[^.]+$/, "") === resumeIcSession.sourceName,
-          ) ??
-          null)
+        ? ((resumeIcSession.imageId == null
+            ? selectedProject.images.find(
+                (img) =>
+                  img.name.replace(/\.[^.]+$/, "") ===
+                  resumeIcSession.sourceName,
+              )
+            : selectedProject.images.find(
+                (img) => img.id === resumeIcSession.imageId,
+              )) ?? null)
         : null;
+      // An unresolvable resume must not fall through to the classifier: it
+      // would mount on the first pending page, and queueing there would pair
+      // this session's GameraXML with that other page's image.
+      if (resumeIcSession && !resumeImage)
+        return (
+          <IcSessionUnavailable
+            sourceName={resumeIcSession.sourceName}
+            sessionId={resumeIcSession.sessionId}
+            onBack={() => setView("project")}
+            onOpenClassifier={goToIc}
+          />
+        );
       // A saved session's page is normally still pending, but it doesn't have
       // to be (its page may have been encoded by some other route). Add it
       // back rather than silently ignoring the click - and so the queued XML

--- a/landing-page/src/components/project/IcSessionsModal.tsx
+++ b/landing-page/src/components/project/IcSessionsModal.tsx
@@ -67,7 +67,7 @@ export default function IcSessionsModal({
       origin = null;
     }
     function onMessage(e: MessageEvent) {
-      if (origin && e.origin !== origin) return;
+      if (!origin || e.origin !== origin) return;
       const data = e.data;
       if (
         data?.type === "ic:resume-session" &&

--- a/landing-page/src/components/project/IcSessionsModal.tsx
+++ b/landing-page/src/components/project/IcSessionsModal.tsx
@@ -2,9 +2,22 @@ import { useEffect, useState } from "react";
 import Modal from "../shared/Modal";
 import { apiFetch } from "../../lib/apiFetch";
 
+export interface IcResumeRequest {
+  sessionId: string;
+  /** mothra's project_images.id for the session's page — IC stores it when
+   * the session is staged, so it maps straight back to a ProjectImage. */
+  imageId: string | null;
+  sourceName: string;
+}
+
 interface IcSessionsModalProps {
   projectId: number;
   onClose: () => void;
+  /** Clicking an in-progress session asks the host to open it. Deliberately
+   * not handled inside this modal: IC's SessionView on its own is missing the
+   * filmstrip, clef controls and encode queue that make the session useful,
+   * so the IC step page opens it instead. */
+  onResumeSession: (req: IcResumeRequest) => void;
 }
 
 // Manage this project's saved Interactive Classifier sessions. The whole
@@ -14,6 +27,7 @@ interface IcSessionsModalProps {
 export default function IcSessionsModal({
   projectId,
   onClose,
+  onResumeSession,
 }: IcSessionsModalProps) {
   const [icUrl, setIcUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -40,6 +54,36 @@ export default function IcSessionsModal({
       cancelled = true;
     };
   }, [projectId]);
+
+  // IC's manage page posts this instead of resuming in place when it's
+  // embedded (see the ic submodule's App.tsx). Accept it only from IC's own
+  // origin, the same guard InteractiveClassifier uses for its messages.
+  useEffect(() => {
+    if (!icUrl) return;
+    let origin: string | null = null;
+    try {
+      origin = new URL(icUrl).origin;
+    } catch {
+      origin = null;
+    }
+    function onMessage(e: MessageEvent) {
+      if (origin && e.origin !== origin) return;
+      const data = e.data;
+      if (
+        data?.type === "ic:resume-session" &&
+        typeof data.sessionId === "string"
+      ) {
+        onResumeSession({
+          sessionId: data.sessionId,
+          imageId: typeof data.imageId === "string" ? data.imageId : null,
+          sourceName:
+            typeof data.sourceName === "string" ? data.sourceName : "",
+        });
+      }
+    }
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, [icUrl, onResumeSession]);
 
   return (
     <Modal onClose={onClose} size="5xl" backdrop="dark">

--- a/landing-page/src/components/project/ProjectDetail.tsx
+++ b/landing-page/src/components/project/ProjectDetail.tsx
@@ -8,6 +8,7 @@ import type { useTextFindingSettings } from "../../hooks/useTextFindingSettings"
 import RenameModal from "./RenameModal";
 import DeleteProjectModal from "./DeleteProjectModal";
 import IcSessionsModal from "./IcSessionsModal";
+import type { IcResumeRequest } from "./IcSessionsModal";
 import ActivityLog from "./ActivityLog";
 import ImageTab from "./ImageTab";
 import ModelTab from "./ModelTab";
@@ -44,6 +45,9 @@ interface ProjectDetailProps {
   }) => void;
   stepsUnlocked: number;
   onStepClick: (step: number) => void;
+  /** Open a saved IC session picked in the "manage IC sessions" modal on the
+   * IC step page (step 1), rather than inside the modal's iframe. */
+  onResumeIcSession: (req: IcResumeRequest) => void;
   onSendToCantus: () => void;
   sendingBundle?: boolean;
   sendBundleError?: string | null;
@@ -88,6 +92,7 @@ export default function ProjectDetail({
   onUsedNamesChange,
   stepsUnlocked,
   onStepClick,
+  onResumeIcSession,
   onSendToCantus,
   sendingBundle = false,
   sendBundleError = null,
@@ -128,6 +133,10 @@ export default function ProjectDetail({
   const [projectRenameName, setProjectRenameName] = useState("");
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [icSessionsModal, setIcSessionsModal] = useState(false);
+  // Saved IC sessions for this project, or null while unknown (still loading,
+  // or IC didn't answer). Sessions live in IC's store, so this is the only way
+  // to know they exist - see the gate on the "manage IC sessions" button.
+  const [icSessionCount, setIcSessionCount] = useState<number | null>(null);
   const [loadedCantusSource, setLoadedCantusSource] =
     useState<CantusSource | null>(null);
   const [imageSubTab, setImageSubTab] = useState<"grid" | "batch">("grid");
@@ -142,6 +151,24 @@ export default function ProjectDetail({
     setBatchEndFolio("");
     setBatchImages([]);
   }, [project.id]);
+
+  // Re-read on modal close too: sessions can be deleted in there, and the
+  // count is in the button's own label.
+  useEffect(() => {
+    let cancelled = false;
+    apiFetch(`/api/projects/${project.id}/ic/session-count`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (!cancelled)
+          setIcSessionCount(typeof d?.count === "number" ? d.count : null);
+      })
+      .catch(() => {
+        if (!cancelled) setIcSessionCount(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [project.id, icSessionsModal]);
 
   const batchFolioSequence = useMemo(() => {
     const folios = loadedCantusSource?.folios ?? [];
@@ -381,12 +408,22 @@ export default function ProjectDetail({
             >
               export all files ↓
             </button>
-            {stepsUnlocked >= 1 && (
+            {/* Hidden only when IC positively reports no sessions AND the IC
+                step was never reached. `stepsUnlocked >= 1` alone used to gate
+                this, which hid the button in exactly the cases where a saved
+                session most needs clearing - sessions can exist at step 0 (see
+                ic_api.py's session-count endpoint). A null count means IC
+                didn't answer, so show it and let the modal report the error
+                rather than silently hiding the only way in. */}
+            {(icSessionCount === null ||
+              icSessionCount > 0 ||
+              stepsUnlocked >= 1) && (
               <button
                 onClick={() => setIcSessionsModal(true)}
                 className="text-xs text-white/60 hover:text-white text-left px-3 py-2 rounded-xl hover:bg-white/10 cursor-pointer transition-colors"
               >
                 manage IC sessions
+                {icSessionCount ? ` (${icSessionCount})` : ""}
               </button>
             )}
           </div>
@@ -993,6 +1030,10 @@ export default function ProjectDetail({
         <IcSessionsModal
           projectId={project.id}
           onClose={() => setIcSessionsModal(false)}
+          onResumeSession={(req) => {
+            setIcSessionsModal(false);
+            onResumeIcSession(req);
+          }}
         />
       )}
     </div>

--- a/landing-page/src/components/workflow/IcSessionUnavailable.tsx
+++ b/landing-page/src/components/workflow/IcSessionUnavailable.tsx
@@ -1,0 +1,70 @@
+interface IcSessionUnavailableProps {
+  /** IC's stored page name for the session (a file-name stem), "" if it
+   * recorded none. */
+  sourceName: string;
+  sessionId: string;
+  onBack: () => void;
+  /** Enter the IC step normally, dropping the resume request. */
+  onOpenClassifier: () => void;
+}
+
+// Shown in place of the classifier when a saved session was picked in "manage
+// IC sessions" but the page it belongs to can't be resolved in this project -
+// the image was deleted, or the session predates IC recording mothra's image
+// id and its name no longer matches one.
+//
+// Mounting the classifier anyway is not a harmless fallback: it would open on
+// whatever page is first in the list, and queueing from there pairs *this*
+// session's GameraXML with that other page's image and filename
+// (InteractiveClassifier's handleQueuePage builds the pair from the selected
+// page), so the classifications would be encoded against the wrong folio with
+// nothing to flag it. Refusing is the only safe option.
+export default function IcSessionUnavailable({
+  sourceName,
+  sessionId,
+  onBack,
+  onOpenClassifier,
+}: IcSessionUnavailableProps) {
+  return (
+    <div className="animate-fade-in flex-1 min-h-0 bg-[#4AADAA] flex flex-col items-center justify-center gap-4 px-8 text-center">
+      <h1 className="text-3xl font-bold italic text-white">
+        saved session unavailable
+      </h1>
+      <p className="max-w-xl text-sm text-white/80">
+        {sourceName ? (
+          <>
+            the page this session was classifying (
+            <span className="font-mono">{sourceName}</span>) is no longer one of
+            this project's images, so the classifier can't open it against the
+            right page.
+          </>
+        ) : (
+          <>
+            this session doesn't record which of this project's pages it belongs
+            to, so the classifier can't open it against the right page.
+          </>
+        )}
+      </p>
+      <p className="max-w-xl text-xs text-white/50">
+        opening it on another page would attach these classifications to the
+        wrong image when the page is queued for encoding. delete the session
+        from "manage IC sessions" on the project page, or carry on without it.
+      </p>
+      <p className="font-mono text-[11px] text-white/30">session {sessionId}</p>
+      <div className="mt-1 flex items-center gap-3">
+        <button
+          onClick={onBack}
+          className="px-6 py-2 bg-white text-[#1D3335] rounded-xl hover:opacity-90 cursor-pointer font-semibold"
+        >
+          back to project
+        </button>
+        <button
+          onClick={onOpenClassifier}
+          className="px-6 py-2 bg-[#1D3335] text-white border border-white/30 rounded-xl hover:opacity-90 cursor-pointer font-semibold"
+        >
+          open classifier without it
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/landing-page/src/components/workflow/InteractiveClassifier.tsx
+++ b/landing-page/src/components/workflow/InteractiveClassifier.tsx
@@ -4,8 +4,18 @@ import { apiFetch } from "../../lib/apiFetch";
 import { AuthImage } from "../shared/AuthImage";
 
 interface InteractiveClassifierProps {
+  // Only the pages step 1 still has work for - see pendingIcImages().
   images: ProjectImage[];
+  // Page to open on instead of the first one - set when the user picked a
+  // saved session in "manage IC sessions". Nothing session-specific needs to
+  // be threaded through beyond this: /ic/start resumes whatever session is
+  // saved for the selected page, and IC keeps at most one per page.
+  initialImageName?: string | null;
+  // How many pages the project has selected in total, pending or not. Lets the
+  // empty state tell "nothing selected yet" apart from "all already encoded".
+  usedImageCount: number;
   projectId: number | null;
+  onBack: () => void;
   onEncodeBatch: (pairs: { xmlFile: File; imageFile: File }[]) => void;
   clefShape: "C" | "F";
   onClefShapeChange: (s: "C" | "F") => void;
@@ -17,14 +27,25 @@ const stemOf = (name: string) => name.replace(/\.[^.]+$/, "");
 
 export default function InteractiveClassifier({
   images,
+  initialImageName = null,
+  usedImageCount,
   projectId,
+  onBack,
   onEncodeBatch,
   clefShape,
   onClefShapeChange,
   clefLine,
   onClefLineChange,
 }: InteractiveClassifierProps) {
-  const [currentIdx, setCurrentIdx] = useState(0);
+  // Resolved once, at mount: this view is remounted on every entry (AppRouter
+  // switches on `view`), and after that the filmstrip owns the selection - a
+  // resume shouldn't keep yanking the user back to its page.
+  const [currentIdx, setCurrentIdx] = useState(() => {
+    const i = initialImageName
+      ? images.findIndex((im) => im.name === initialImageName)
+      : -1;
+    return i === -1 ? 0 : i;
+  });
   const [icUrl, setIcUrl] = useState<string | null>(null);
   const [icOrigin, setIcOrigin] = useState<string | null>(null);
   // Set only once the user finishes IC's create-session screen (the iframe
@@ -312,6 +333,13 @@ export default function InteractiveClassifier({
   return (
     <div className="animate-fade-in flex-1 min-h-0 bg-[#4AADAA] flex flex-col pb-3">
       <div className="flex items-center gap-6 px-8 py-3">
+        <button
+          onClick={onBack}
+          title="back to project"
+          className="text-white text-2xl hover:opacity-70 transition-opacity cursor-pointer shrink-0"
+        >
+          ←
+        </button>
         <h1 className="text-4xl font-bold italic text-white">
           interactive classifier
         </h1>
@@ -470,8 +498,27 @@ export default function InteractiveClassifier({
         {/* IC editor area */}
         <div className="flex-1 min-h-0 flex items-stretch justify-stretch overflow-hidden">
           {images.length === 0 ? (
-            <div className="flex-1 flex items-center justify-center text-white/40 text-sm italic">
-              no images selected
+            // Reached by navigating to step 1 once every selected page is
+            // already encoded (each one is past step 1, so pendingIcImages()
+            // filters them all out) - the classifier has nothing to stage, so
+            // say which case this is instead of showing an empty canvas.
+            <div className="flex-1 flex flex-col items-center justify-center gap-3 text-center px-8">
+              <p className="text-white/70 text-sm">
+                {usedImageCount === 0
+                  ? "no pages are selected for this project yet"
+                  : `every selected page (${usedImageCount}) has already been classified and encoded`}
+              </p>
+              <p className="text-white/40 text-xs max-w-md">
+                {usedImageCount === 0
+                  ? "select images on the project page and run detection first."
+                  : "there's nothing left to classify here — carry on with correction (step 3), or select more pages on the project page."}
+              </p>
+              <button
+                onClick={onBack}
+                className="mt-1 px-6 py-2 bg-white text-[#1D3335] rounded-xl hover:opacity-90 cursor-pointer font-semibold"
+              >
+                back to project
+              </button>
             </div>
           ) : status === "error" ? (
             <div className="flex-1 flex flex-col items-center justify-center gap-2 text-center px-8">

--- a/landing-page/src/utils/imageStep.ts
+++ b/landing-page/src/utils/imageStep.ts
@@ -1,4 +1,4 @@
-import type { AnnotationSet, MeiFile } from "../types";
+import type { AnnotationSet, MeiFile, ProjectImage } from "../types";
 
 export interface ImageProgress {
   nextStep: number; // 1=ic, 3=neon, 4=send
@@ -25,6 +25,33 @@ export function getImageProgress(
   if (stepsUnlocked >= 1 && annotations.some((a) => a.imageName === imageName))
     return { nextStep: 1, badge: "ic" };
   return null;
+}
+
+// The used images the interactive classifier still has work for: never
+// predicted (progress null) or predicted but not yet encoded (nextStep 1).
+// An image that already has an MEI file is past step 1 and drops out - which
+// is why this can legitimately come back empty once every page is encoded
+// (InteractiveClassifier renders an explanatory empty state for that).
+export function pendingIcImages(
+  images: ProjectImage[],
+  usedImageNames: string[],
+  annotations: AnnotationSet[],
+  meiFiles: MeiFile[],
+  stepsUnlocked: number,
+): ProjectImage[] {
+  const progressOf = (name: string) =>
+    getImageProgress(name, annotations, meiFiles, stepsUnlocked);
+  return images
+    .filter((img) => {
+      if (!usedImageNames.includes(img.name)) return false;
+      const p = progressOf(img.name);
+      return p === null || p.nextStep <= 1;
+    })
+    .sort(
+      (a, b) =>
+        (progressOf(a.name)?.nextStep ?? 0) -
+        (progressOf(b.name)?.nextStep ?? 0),
+    );
 }
 
 export function minNextStep(


### PR DESCRIPTION
Three related fixes to the interactive-classifier step, all reachable from the project page.

**Blank IC step (#185).** Navigating to step 1 once every selected page was encoded left an all-but-blank canvas: the list filters to pages step 1 still has work for, so it came back empty and rendered a single line of faint italic text with no way out. It now distinguishes "nothing selected yet" from "all pages already encoded", and the page gains the back control every other workflow page (`ProjectDetail`, `NeonBatchEditor`, `ProcessingPage`, the completion pages) already had — IC was the only one with no exit at all.

**Saved sessions now open on the IC step rather than inside the modal.** Clicking an in-progress session in "manage IC sessions" swapped the modal's iframe for a bare `SessionView`, which has none of the filmstrip, clef controls or encode queue that make a session workable. IC's manage page now posts `ic:resume-session` to the host, and mothra selects that page on the IC step. Nothing session-specific has to be threaded through the UI: `/ic/start` already resumes by `(project_id, image_id)`, and IC keeps at most one session per page (unique index in its `db_store`), so selecting the page re-opens exactly the session that was clicked. This needs the matching `ic` submodule bump to `dbe9441`, already merged on `DDMAL/ic@main`.

**"manage IC sessions" was hidden in the cases where it matters most.** It was gated on `stepsUnlocked >= 1`, but sessions can exist while that is still 0 — the `VITE_SKIP_PREDICT` dev path goes straight to IC, and a batch text-finding job that fails after its YOLO stage leaves annotations behind without advancing the step. Those are exactly the situations where a stale session needs clearing. A new `GET /projects/{id}/ic/session-count` lets the button key off real sessions, and it fails open: an unreachable IC shows the button and lets the modal report the error, rather than silently hiding the only way in.

Also extracts `pendingIcImages()` from the filter-and-sort that was inline-duplicated across two `AppRouter` cases. Behaviour-preserving.

**Testing.** `tsc -b`, eslint and prettier are clean on both `landing-page` and the `ic` frontend — the pre-existing eslint findings in these files were checked against `main` to confirm nothing new was introduced. The IC bundle was rebuilt and confirmed served locally. The resume click-through has not been exercised end-to-end against a live saved session, so that is worth a manual pass before merging.

Closes #185


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to view the number of saved Interactive Classifier sessions for a project.
  * Added resume support for saved sessions, reopening the relevant image and classification progress.
  * Added back navigation from the Interactive Classifier to the project.
  * Improved project controls for managing saved sessions.
* **Bug Fixes**
  * Improved image selection and progress tracking for classification and encoding.
  * Added clearer guidance when no images are available or all images are complete.
  * Improved handling of unavailable or invalid session data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->