### PR TITLE
Fix: garbled project name rendering in TruncatedName

### DIFF
--- a/landing-page/src/components/shared/TruncatedName.tsx
+++ b/landing-page/src/components/shared/TruncatedName.tsx
@@ -15,15 +15,40 @@ interface TruncatedNameProps {
 // manuscript filenames from each other. This instead always keeps the last
 // `tailLength` characters of `name` (plus `suffix`, if any) visible, and lets
 // only the shared prefix ellipsize when space runs out.
+// Below this many characters, ellipsizing the head saves too little space to
+// be worth splitting off its own box — and a head that short is exactly what
+// triggers the two rendering bugs below, so folding it into `tail` instead
+// sidesteps both.
+const MIN_HEAD_LENGTH = 3;
+// Never collapsed or trimmed by CSS whitespace rules, unlike a regular space.
+const NBSP = " ";
+
 export default function TruncatedName({
   name,
   suffix = "",
   tailLength = 14,
   className = "",
 }: TruncatedNameProps) {
-  const hasHead = name.length > tailLength;
-  const head = hasHead ? name.slice(0, name.length - tailLength) : "";
-  const tail = hasHead ? name.slice(name.length - tailLength) : name;
+  const hasHead = name.length > tailLength + MIN_HEAD_LENGTH;
+  let head = "";
+  let tail = name;
+
+  if (hasHead) {
+    head = name.slice(0, name.length - tailLength);
+    tail = name.slice(name.length - tailLength);
+
+    // The split point can land on/next to whitespace in `name`. Rendered in
+    // separate boxes, that space sits at the very edge of one span's own
+    // line box, where the browser's normal whitespace-collapsing trims it
+    // away entirely (issue #192) — fusing two words with no visible gap.
+    // Trim it from both sides and reinsert a single non-breaking space so
+    // exactly one space survives, same as if the string had never been split.
+    const trimmedHead = head.replace(/\s+$/, "");
+    const hadBoundarySpace = trimmedHead.length !== head.length || /^\s/.test(tail);
+    head = trimmedHead;
+    tail = tail.replace(/^\s+/, "");
+    if (hadBoundarySpace) tail = NBSP + tail;
+  }
 
   return (
     <span


### PR DESCRIPTION
## Summary
- Fixes #192: project names on the landing page sometimes rendered garbled (a fake gap splitting a word, or a real space silently disappearing) depending on incidental name length.
- Root cause: `TruncatedName` splits `name` into an ellipsized `head` and an always-visible `tail` at a fixed character offset. That offset has no awareness of where whitespace falls in the name, so a one-character difference in length (e.g. one space vs. two) could shift the cut onto/next to a space and either pad in a fake gap (via the head span's `min-w-[1.2em]` floor when the head is only 1-2 characters) or silently collapse a real space to nothing (leading whitespace trimmed at the start of the tail span's own line box).
- Fix: fold heads under 4 characters into the tail entirely (not worth splitting off for ~1-3 characters of savings, and it's exactly what triggers the fake-gap bug), and reinsert a single non-breaking space at the split boundary whenever it lands on whitespace, so exactly one space survives instead of zero.

## Relative to #130
This file was patched twice before for #130 (long names hiding their distinguishing folio-number suffix). This change doesn't touch either of those fixes: the `min-w-[1.2em]` head-span floor and the missing `max-w-full` on the tail span are both left exactly as they were, and #130's own reported example (`Einsiedeln__Stiftsbibliothek__Codex_611_010r`, head length 30) is well above the new threshold and completely unaffected.

There is one narrower trade-off worth calling out: names whose head would be only 1-3 characters (arithmetically, not #130's actual case) no longer get a head span at all. That's correct when there's room to show the full name, but if such a name is ever displayed in a genuinely too-narrow container, it will now hard-clip with no "…" instead of a minimal graceful ellipsis. This hasn't been reported by anyone as an actual bug — it's a theoretical edge case identified while fixing #192.

## Test plan
- [x] `tsc --noEmit` and `eslint` pass clean.
- [x] Logic simulated in isolation against the two reported names, the #130 regression case, the head-length 3-vs-4 threshold boundary, and the non-default `tailLength=10` call site (`MeiCompareModal`) — confirmed the reinserted character is a genuine U+00A0.
- [x] Manually verified in a local dev server: renamed a project to `NZ other folios` and `NZ  other folios` — both now render identically with no gap or missing space. Uploaded a long filename (`Einsiedeln__Stiftsbibliothek__Codex_611_010r.jpg`) in the Images tab and narrowed the window — still ellipsizes cleanly, confirming the #130 fix is intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved display of long names by applying truncation only when needed.
  - Preserved visible spacing at the split point, including non-breaking spaces where appropriate.
  - Shorter names now remain displayed in full without unnecessary splitting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->