### PR TITLE
Move classifier controls to the project page and add auto/manual IC modes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -482,6 +482,8 @@ rollout restart`) remains the safer habit.
 | `landing-page/src/lib/apiFetch.ts` | `apiFetch` (also drives the silent JWT-refresh-on-401 flow via `X-Refresh-Token`) / `apiFetchJobStream` — auth-aware fetch wrapper + job kickoff-then-stream helper, reports `job_id` via an `onJobId` callback |
 | `landing-page/src/types.ts` | All shared TypeScript types |
 | `landing-page/src/components/AppRouter.tsx` | All view routing (switch on `view` string) |
+| `landing-page/src/hooks/useIcSettings.ts` | IC step mode (auto/manual) + shared training set — see **Workflow pipeline** step 2 |
+| `landing-page/src/utils/icQueue.ts` | Shared IC-queue helpers (`buildEncodePair`, `autoQueueImage`) used by both IC modes |
 | `landing-page/src/hooks/useEncodingFlow.ts` | Encoding state: pending files, logs, MEI content |
 | `landing-page/src/hooks/useProjectMutations.ts` | Project CRUD mutations |
 | `landing-page/src/hooks/useAssetSection.tsx` | Shared state for grid tabs (selection, pagination, modal, drag) |
@@ -492,7 +494,7 @@ rollout restart`) remains the safer habit.
 
 ```
 1. Create project, upload images ("use" selected images)
-2. Interactive Classifier  →  view: "ic"
+2. Interactive Classifier  →  view: "ic" (manual) / "ic-auto" (auto)
 3. IC completion / upload XML output  →  view: "ic-completion"
 4. Encoding (GameraXML → MEI via encode_to_mei.py)  →  view: "encoding-processing"
 5. Neon.js batch editor for human correction  →  view: "neon-editor"
@@ -500,6 +502,34 @@ rollout restart`) remains the safer habit.
 ```
 
 `stepsUnlocked` on the project record gates which steps are accessible. It increments as each step completes and is persisted via `PUT /api/projects/{id}`.
+
+**Step 2 has two modes, chosen before the pipeline runs.** The "Classifier
+settings" column of the project page's settings box (`IcSettingsSection.tsx`,
+rendered beside the "CantusDB settings" column inside `CantusSourcePanel.tsx`)
+holds an auto/manual switch plus the shared training set (built-in presets from `GET /api/ic/training-presets` +
+uploaded GameraXML), in state at `useIcSettings.ts`. Both used to live on the
+IC page itself — a "training set" popover in its top bar and a "queue all
+available" button in its filmstrip — and were moved here so the choice is made
+once, alongside image/model selection, rather than mid-classification.
+- **auto** (default) → view `"ic-auto"` (`IcAutoQueue.tsx`): no classifier
+  interface at all. Every pending page is classified server-side through
+  `POST /projects/{id}/ic/auto-queue` (sequentially, as the old "queue all
+  available" did) and the resulting queue goes straight to
+  `"encoding-processing"`. Needs a non-empty training set — classify has no
+  training pool otherwise — so `ProjectDetail.tsx` greys out Continue
+  (`autoIcNeedsTraining`, checked at steps 0 and 1) until one is picked, rather
+  than letting a whole detection run be spent first. Because auto is the
+  default, that greyed-out Continue is what a brand-new project sees until
+  training data is picked or the switch is flipped to manual.
+- **manual** (the pre-existing behaviour) → view `"ic"`: the classifier opens
+  per page, and the training set above is pre-selected in each page's
+  create-session screen via the `ic:prefill-training` postMessage. No selection
+  made ⇒ no prefill, and the classifier's own defaults stand.
+
+`AppRouter.tsx`'s `goToIc()` picks the view from the mode, so every ordinary
+route into step 2 (Continue, the completion page, the progress sidebar) honours
+it. Resuming a saved session from "manage IC sessions" always opens `"ic"`
+regardless of mode — the user picked that session explicitly.
 
 Step 6 is **not** a live push to Cantus Ultimus — the DDMAL/cantus (Cantus
 Ultimus) repo has no write API (its DRF views are all `ListAPIView`/

--- a/landing-page/src/components/AppRouter.tsx
+++ b/landing-page/src/components/AppRouter.tsx
@@ -14,6 +14,7 @@ import { downloadBlob } from "../utils/download";
 import type { useProjectMutations } from "../hooks/useProjectMutations";
 import { useInferenceSettings } from "../hooks/useInferenceSettings";
 import { useTextFindingSettings } from "../hooks/useTextFindingSettings";
+import { useIcSettings } from "../hooks/useIcSettings";
 import Hero from "./landing/Hero";
 import Documentation from "./documentation/Documentation";
 import AuthPage from "./auth/AuthPage";
@@ -24,6 +25,7 @@ import type { IcResumeRequest } from "./project/IcSessionsModal";
 import ProcessingPage from "./workflow/ProcessingPage";
 import CompletionPage from "./workflow/CompletionPage";
 import InteractiveClassifier from "./workflow/InteractiveClassifier";
+import IcAutoQueue from "./workflow/IcAutoQueue";
 import IcSessionUnavailable from "./workflow/IcSessionUnavailable";
 import IcCompletionTestPage from "./workflow/ICCompletionTestPage";
 import NeonCompletionPage from "./workflow/NeonCompletionPage";
@@ -160,6 +162,9 @@ export default function AppRouter({
   // thread inference settings + text-finding settings (mothra-text optional inputs)
   const inferenceSettings = useInferenceSettings();
   const textFindingSettings = useTextFindingSettings();
+  // IC step settings (auto/manual + shared training set), picked on the
+  // project page — see IcSettingsSection.
+  const icSettings = useIcSettings();
 
   // batch text-alignment run (run_chain.py) state
   const [batchRunIds, setBatchRunIds] = useState<{
@@ -224,6 +229,7 @@ export default function AppRouter({
       "processing",
       "completion",
       "ic",
+      "ic-auto",
       "encoding-processing",
       "encoding-completion",
       "neon-editor",
@@ -232,14 +238,33 @@ export default function AppRouter({
     if (PROJECT_VIEWS.includes(view) && !selectedProject) setView("projects");
   }, [view, selectedProject]);
 
-  // Ordinary way into the IC step: start on the first page to classify. Any
-  // saved-session resume left over from a previous visit is dropped here, so
-  // only the "manage IC sessions" path (which sets it) ever opens one - the
-  // request has to outlive the navigation itself, since the "ic" case below
-  // keeps reading it to hold the session's page in the filmstrip.
+  // Ordinary way into the IC step. Any saved-session resume left over from a
+  // previous visit is dropped here, so only the "manage IC sessions" path
+  // (which sets it) ever opens one - the request has to outlive the navigation
+  // itself, since the "ic" case below keeps reading it to hold the session's
+  // page in the filmstrip.
+  //
+  // "auto" mode never shows the classifier: it classifies and queues every
+  // pending page with the project page's training set, then goes straight to
+  // encoding (see IcAutoQueue). "manual" opens the classifier on the first
+  // page to classify. A saved-session resume always goes to the classifier -
+  // the user picked that session explicitly.
   const goToIc = () => {
     setResumeIcSession(null);
-    setView("ic");
+    setView(icSettings.mode === "auto" ? "ic-auto" : "ic");
+  };
+
+  // Hand a finished IC queue (either mode) to the batch encoder.
+  const startEncodeBatch = (pairs: { xmlFile: File; imageFile: File }[]) => {
+    setPendingBatchPairs(pairs);
+    setBatchSummary(null);
+    if (selectedProjectId && selectedProject) {
+      updateProjectSteps(
+        selectedProjectId,
+        Math.max(selectedProject.stepsUnlocked, 2),
+      );
+    }
+    setView("encoding-processing");
   };
 
   switch (view) {
@@ -438,6 +463,7 @@ export default function AppRouter({
           }}
           inferenceSettings={inferenceSettings}
           textFindingSettings={textFindingSettings}
+          icSettings={icSettings}
         />
       ) : null;
     case "processing":
@@ -778,16 +804,32 @@ export default function AppRouter({
           onClefShapeChange={setClefShape}
           clefLine={clefLine}
           onClefLineChange={setClefLine}
-          onEncodeBatch={(pairs) => {
-            setPendingBatchPairs(pairs);
-            setBatchSummary(null);
-            if (selectedProjectId && selectedProject) {
-              updateProjectSteps(
-                selectedProjectId,
-                Math.max(selectedProject.stepsUnlocked, 2),
-              );
-            }
-            setView("encoding-processing");
+          trainingPresets={icSettings.trainingPresets}
+          trainingFiles={icSettings.trainingFiles}
+          onEncodeBatch={startEncodeBatch}
+        />
+      );
+    }
+    case "ic-auto": {
+      if (!selectedProject) return null;
+      return (
+        <IcAutoQueue
+          images={pendingIcImages(
+            selectedProject.images,
+            selectedProject.usedImageNames,
+            selectedProject.annotations ?? [],
+            selectedProject.meiFiles ?? [],
+            selectedProject.stepsUnlocked,
+          )}
+          usedImageCount={selectedProject.usedImageNames.length}
+          projectId={selectedProjectId}
+          trainingPresets={icSettings.trainingPresets}
+          trainingFiles={icSettings.trainingFiles}
+          onDone={startEncodeBatch}
+          onBack={() => setView("project")}
+          onOpenManualClassifier={() => {
+            setResumeIcSession(null);
+            setView("ic");
           }}
         />
       );

--- a/landing-page/src/components/project/CantusSourcePanel.tsx
+++ b/landing-page/src/components/project/CantusSourcePanel.tsx
@@ -2,9 +2,11 @@ import { useState, useEffect, useRef } from "react";
 import type { CantusSource, Project, ProjectImage } from "../../types";
 import { apiFetchOrThrow } from "../../lib/apiFetch";
 import type { useTextFindingSettings } from "../../hooks/useTextFindingSettings";
+import type { useIcSettings } from "../../hooks/useIcSettings";
 import { findFolioConflict, compareFolios } from "../../utils/folio";
 import { downloadBlob } from "../../utils/download";
 import FolioSelect from "../shared/FolioSelect";
+import IcSettingsSection from "./IcSettingsSection";
 
 // Persists across CantusSourcePanel unmount/remount (e.g. navigating to the
 // processing/IC view and back) so a slow or failed background revalidation
@@ -23,6 +25,7 @@ interface CantusSourcePanelProps {
   onBatchEndFolioChange: (folio: string) => void;
   batchFolioSequence: string[];
   locked: boolean;
+  icSettings: ReturnType<typeof useIcSettings>;
 }
 
 export default function CantusSourcePanel({
@@ -37,6 +40,7 @@ export default function CantusSourcePanel({
   onBatchEndFolioChange,
   batchFolioSequence,
   locked,
+  icSettings,
 }: CantusSourcePanelProps) {
   const { ocrOnlyMode, sourceId, folio, patch } = textFindingSettings;
   const [sourceIdInput, setSourceIdInput] = useState(sourceId);
@@ -146,151 +150,170 @@ export default function CantusSourcePanel({
   }, [project.id, project.cantusSourceId]);
 
   return (
-    <div className="mb-4 bg-white/10 rounded-xl p-4 flex flex-col gap-3 text-sm text-white max-w-xl">
-      <label className="flex items-center gap-2 text-white/80 text-xs">
-        <input
-          type="checkbox"
-          checked={ocrOnlyMode}
-          onChange={(e) => patch({ ocrOnlyMode: e.target.checked })}
-          className="accent-[#1D3335]"
-        />
-        OCR only (skip CantusDB alignment)
-      </label>
+    // Two settings columns side by side: the Cantus source (left) and the IC
+    // step (right). Both are pre-run choices, and side-by-side keeps the panel
+    // from pushing the tab bar below the fold.
+    <div className="mb-4 bg-white/10 rounded-xl p-4 flex gap-8 text-sm text-white max-w-3xl">
+      <div className="flex flex-col gap-3 flex-[2] min-w-0">
+        <h3 className="text-base text-white font-semibold">
+          CantusDB settings
+        </h3>
+        <label className="flex items-center gap-2 text-white/80 text-xs">
+          <input
+            type="checkbox"
+            checked={ocrOnlyMode}
+            onChange={(e) => patch({ ocrOnlyMode: e.target.checked })}
+            className="accent-[#1D3335]"
+          />
+          OCR only (skip CantusDB alignment)
+        </label>
 
-      {!ocrOnlyMode && (
-        <div className="flex flex-col gap-3 pl-1">
-          <div className="flex items-center gap-2">
-            <input
-              type="text"
-              value={sourceIdInput}
-              onChange={(e) => setSourceIdInput(e.target.value)}
-              placeholder="CantusDB source ID"
-              disabled={locked}
-              className="bg-[#1D3335] border border-white/30 rounded px-2 py-1 text-sm text-white outline-none w-40"
-            />
-            <button
-              onClick={handleLoad}
-              disabled={
-                loading ||
-                !sourceIdInput.trim() ||
-                locked ||
-                sourceIdInput.trim() === loadedSource?.sourceId
-              }
-              className="px-3 py-1 border border-white/40 text-white text-xs rounded-lg hover:opacity-90 cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
-            >
-              {loading ? "loading..." : "load"}
-            </button>
-          </div>
-          {locked ? (
-            <p className="text-white/50 text-xs w-fit">
-              source is locked - this project has already moved past the upload
-              step
-            </p>
-          ) : (
-            <a
-              href="https://cantusdatabase.org/sources/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-white/50 text-xs hover:text-white underline w-fit"
-            >
-              don't know your source ID?
-            </a>
-          )}
-          {error && <p className="text-red-200 text-xs">{error}</p>}
-          {loadedSource && (
-            <div className="flex flex-col gap-2">
-              <div className="flex items-center gap-2">
-                <p className="text-white/80 text-xs">{loadedSource.name}</p>
-                <button
-                  onClick={async () => {
-                    setExportError(null);
-                    try {
-                      const r = await apiFetchOrThrow(
-                        `/api/projects/${project.id}/sources/${loadedSource.sourceId}/export`,
-                      );
-                      downloadBlob(
-                        await r.blob(),
-                        `source-${loadedSource.sourceId}-export.zip`,
-                      );
-                    } catch (e) {
-                      setExportError((e as Error).message);
-                    }
-                  }}
-                  className="text-white/50 hover:text-white text-[10px] underline cursor-pointer"
-                >
-                  download zip
-                </button>
-              </div>
-              {exportError && (
-                <p className="text-red-200 text-xs">{exportError}</p>
-              )}
-              {imageSubTab === "grid" ? (
-                <>
-                  <FolioSelect
-                    value={folio}
-                    options={loadedSource.folios}
-                    onChange={(v) => {
-                      patch({ folio: v });
-                      setConflict(findFolioConflict(project.images, v) ?? null);
-                    }}
-                    className="bg-[#1D3335] border border-white/30 rounded px-2 py-1 text-sm text-white outline-none w-40"
-                  />
-                  {conflict && (
-                    <p className="text-yellow-200 text-xs">
-                      ⚠ folio "{folio}" is already used by {conflict.name}
-                    </p>
-                  )}
-                  {folio ? (
-                    <p className="text-white/50 text-xs">
-                      the next image you upload in the images tab will be tagged
-                      as folio "{folio}"
-                    </p>
-                  ) : (
-                    <p className="text-white/50 text-xs">
-                      select a folio above to tag your next upload —
-                      already-uploaded images keep the folio they were tagged
-                      with
-                    </p>
-                  )}
-                </>
-              ) : (
-                <div className="flex flex-col gap-3">
-                  <div className="flex gap-4">
-                    <label className="flex flex-col gap-1">
-                      <span className="text-xs text-white/70">start folio</span>
-                      <FolioSelect
-                        value={batchStartFolio}
-                        options={loadedSource.folios}
-                        onChange={onBatchStartFolioChange}
-                        className="bg-[#1D3335] border border-white/30 rounded px-2 py-1 text-sm text-white outline-none w-32"
-                      />
-                    </label>
-                    <label className="flex flex-col gap-1">
-                      <span className="text-xs text-white/70">end folio</span>
-                      <FolioSelect
-                        value={batchEndFolio}
-                        options={loadedSource.folios}
-                        onChange={onBatchEndFolioChange}
-                        className="bg-[#1D3335] border border-white/30 rounded px-2 py-1 text-sm text-white outline-none w-32"
-                      />
-                    </label>
-                  </div>
-                  {batchFolioSequence.length > 0 ? (
-                    <p className="text-xs text-white/70">
-                      {batchFolioSequence.length} folio(s) in this range
-                    </p>
-                  ) : (
-                    <p className="text-xs text-white/50">
-                      select a range, then use "+ new image" above to upload —
-                      files are tagged with folios in order
-                    </p>
-                  )}
-                </div>
-              )}
+        {!ocrOnlyMode && (
+          <div className="flex flex-col gap-3 pl-1">
+            <div className="flex items-center gap-2">
+              <input
+                type="text"
+                value={sourceIdInput}
+                onChange={(e) => setSourceIdInput(e.target.value)}
+                placeholder="CantusDB source ID"
+                disabled={locked}
+                className="bg-[#1D3335] border border-white/30 rounded px-2 py-1 text-sm text-white outline-none w-40"
+              />
+              <button
+                onClick={handleLoad}
+                disabled={
+                  loading ||
+                  !sourceIdInput.trim() ||
+                  locked ||
+                  sourceIdInput.trim() === loadedSource?.sourceId
+                }
+                className="px-3 py-1 border border-white/40 text-white text-xs rounded-lg hover:opacity-90 cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                {loading ? "loading..." : "load"}
+              </button>
             </div>
-          )}
-        </div>
-      )}
+            {locked ? (
+              <p className="text-white/50 text-xs w-fit">
+                source is locked - this project has already moved past the
+                upload step
+              </p>
+            ) : (
+              <a
+                href="https://cantusdatabase.org/sources/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-white/50 text-xs hover:text-white underline w-fit"
+              >
+                don't know your source ID?
+              </a>
+            )}
+            {error && <p className="text-red-200 text-xs">{error}</p>}
+            {loadedSource && (
+              <div className="flex flex-col gap-2">
+                <div className="flex items-center gap-2">
+                  <p className="text-white/80 text-xs">{loadedSource.name}</p>
+                  <button
+                    onClick={async () => {
+                      setExportError(null);
+                      try {
+                        const r = await apiFetchOrThrow(
+                          `/api/projects/${project.id}/sources/${loadedSource.sourceId}/export`,
+                        );
+                        downloadBlob(
+                          await r.blob(),
+                          `source-${loadedSource.sourceId}-export.zip`,
+                        );
+                      } catch (e) {
+                        setExportError((e as Error).message);
+                      }
+                    }}
+                    className="text-white/50 hover:text-white text-[10px] underline cursor-pointer"
+                  >
+                    download zip
+                  </button>
+                </div>
+                {exportError && (
+                  <p className="text-red-200 text-xs">{exportError}</p>
+                )}
+                {imageSubTab === "grid" ? (
+                  <>
+                    <FolioSelect
+                      value={folio}
+                      options={loadedSource.folios}
+                      onChange={(v) => {
+                        patch({ folio: v });
+                        setConflict(
+                          findFolioConflict(project.images, v) ?? null,
+                        );
+                      }}
+                      className="bg-[#1D3335] border border-white/30 rounded px-2 py-1 text-sm text-white outline-none w-40"
+                    />
+                    {conflict && (
+                      <p className="text-yellow-200 text-xs">
+                        ⚠ folio "{folio}" is already used by {conflict.name}
+                      </p>
+                    )}
+                    {folio ? (
+                      <p className="text-white/50 text-xs">
+                        the next image you upload in the images tab will be
+                        tagged as folio "{folio}"
+                      </p>
+                    ) : (
+                      <p className="text-white/50 text-xs">
+                        select a folio above to tag your next upload —
+                        already-uploaded images keep the folio they were tagged
+                        with
+                      </p>
+                    )}
+                  </>
+                ) : (
+                  <div className="flex flex-col gap-3">
+                    <div className="flex gap-4">
+                      <label className="flex flex-col gap-1">
+                        <span className="text-xs text-white/70">
+                          start folio
+                        </span>
+                        <FolioSelect
+                          value={batchStartFolio}
+                          options={loadedSource.folios}
+                          onChange={onBatchStartFolioChange}
+                          className="bg-[#1D3335] border border-white/30 rounded px-2 py-1 text-sm text-white outline-none w-32"
+                        />
+                      </label>
+                      <label className="flex flex-col gap-1">
+                        <span className="text-xs text-white/70">end folio</span>
+                        <FolioSelect
+                          value={batchEndFolio}
+                          options={loadedSource.folios}
+                          onChange={onBatchEndFolioChange}
+                          className="bg-[#1D3335] border border-white/30 rounded px-2 py-1 text-sm text-white outline-none w-32"
+                        />
+                      </label>
+                    </div>
+                    {batchFolioSequence.length > 0 ? (
+                      <p className="text-xs text-white/70">
+                        {batchFolioSequence.length} folio(s) in this range
+                      </p>
+                    ) : (
+                      <p className="text-xs text-white/50">
+                        select a range, then use "+ new image" above to upload —
+                        files are tagged with folios in order
+                      </p>
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Step-1 settings share this box - both are choices made before the
+          pipeline runs. Outside the OCR-only branch above: the IC step
+          happens either way. */}
+      <div className="flex-[3] min-w-0 border-l border-white/20 pl-8">
+        <IcSettingsSection icSettings={icSettings} />
+      </div>
     </div>
   );
 }

--- a/landing-page/src/components/project/IcSettingsSection.tsx
+++ b/landing-page/src/components/project/IcSettingsSection.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useState } from "react";
+import { apiFetch } from "../../lib/apiFetch";
+import type { IcMode, useIcSettings } from "../../hooks/useIcSettings";
+
+interface IcSettingsSectionProps {
+  icSettings: ReturnType<typeof useIcSettings>;
+}
+
+const MODES: IcMode[] = ["auto", "manual"];
+
+/**
+ * Step-1 (interactive classifier) settings, laid out in place on the project
+ * page rather than behind a popover on the IC page itself: the mode switch
+ * plus the shared training set (built-in presets + uploaded GameraXML) that
+ * "auto" classifies every page with, and that "manual" pre-selects on each
+ * page in the classifier.
+ */
+export default function IcSettingsSection({
+  icSettings,
+}: IcSettingsSectionProps) {
+  const {
+    mode,
+    setMode,
+    trainingPresets,
+    setTrainingPresets,
+    trainingFiles,
+    setTrainingFiles,
+  } = icSettings;
+  const [availablePresets, setAvailablePresets] = useState<string[]>([]);
+
+  // Same list IC's own create-session screen offers, so a preset picked here
+  // is one the classifier will recognise.
+  useEffect(() => {
+    let cancelled = false;
+    apiFetch("/api/ic/training-presets")
+      .then((r) => (r.ok ? r.json() : []))
+      .then((list) => {
+        if (!cancelled) setAvailablePresets(Array.isArray(list) ? list : []);
+      })
+      .catch(() => {
+        if (!cancelled) setAvailablePresets([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const totalTrainingSets = trainingPresets.length + trainingFiles.length;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <h3 className="text-base text-white font-semibold">
+        Classifier settings
+      </h3>
+
+      <div className="flex flex-col gap-1">
+        <div className="inline-flex rounded-lg border border-white/30 overflow-hidden w-fit">
+          {MODES.map((m) => (
+            <button
+              key={m}
+              onClick={() => setMode(m)}
+              className={`px-4 py-1 text-xs cursor-pointer transition-colors ${
+                mode === m
+                  ? "bg-white text-[#1D3335] font-semibold"
+                  : "text-white/70 hover:bg-white/10"
+              }`}
+            >
+              {m}
+            </button>
+          ))}
+        </div>
+        <span className="text-white/40 text-xs italic">
+          {mode === "auto"
+            ? "every page is classified and queued for you"
+            : "you classify each page in the classifier"}
+        </span>
+      </div>
+
+      {/* "training data" is the section; the preset picker and the upload are
+          its two sub-groups, so they sit a step down in the hierarchy rather
+          than reading as siblings of it. */}
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-0.5">
+          <span className="text-sm font-medium text-white/90">
+            training data
+          </span>
+          <span className="text-xs text-white/40 italic">
+            {mode === "auto"
+              ? "applied to every page"
+              : "pre-selected on each page in the classifier"}
+          </span>
+        </div>
+
+        <div className="flex flex-col gap-2 pl-3 border-l border-white/20">
+          <div className="flex flex-col gap-1">
+            <span className="text-[11px] uppercase tracking-wide text-white/50">
+              presets
+            </span>
+            {availablePresets.length === 0 ? (
+              <span className="text-white/50 text-xs">
+                no built-in presets available
+              </span>
+            ) : (
+              <div className="flex flex-col gap-1 max-h-40 overflow-y-auto">
+                {availablePresets.map((name) => (
+                  <label
+                    key={name}
+                    className="flex items-center gap-2 cursor-pointer text-xs text-white/80"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={trainingPresets.includes(name)}
+                      // Presets are mutually exclusive here for the same reason
+                      // they are in IC's own picker: checking one unchecks the
+                      // rest. Kept as a list because the API takes one, and an
+                      // uploaded set can still be combined with a preset.
+                      onChange={(e) =>
+                        setTrainingPresets(e.target.checked ? [name] : [])
+                      }
+                      className="accent-[#1D3335]"
+                    />
+                    <span className="truncate">{name}</span>
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label className="block">
+              <span className="mb-1 block text-[11px] uppercase tracking-wide text-white/50">
+                upload GameraXML (.xml)
+              </span>
+              <input
+                type="file"
+                accept=".xml"
+                multiple
+                onChange={(e) =>
+                  setTrainingFiles(Array.from(e.target.files ?? []))
+                }
+                className="block w-full text-xs text-white/70 file:mr-2 file:cursor-pointer file:rounded-lg file:border-0 file:bg-[#1D3335] file:px-3 file:py-1.5 file:text-xs file:font-semibold file:text-white hover:file:opacity-90"
+              />
+            </label>
+            {trainingFiles.length > 0 && (
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-white/60">
+                  {trainingFiles.length} file
+                  {trainingFiles.length === 1 ? "" : "s"} selected
+                </span>
+                <button
+                  onClick={() => setTrainingFiles([])}
+                  className="text-white/50 hover:text-white text-[10px] underline cursor-pointer"
+                >
+                  clear
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* No warning for auto-with-no-training-data here: the Continue button
+            on the right already carries that one, greyed out with the reason. */}
+        <p className="text-white/40 text-xs italic">
+          {totalTrainingSets > 0
+            ? `${totalTrainingSets} training set${totalTrainingSets === 1 ? "" : "s"} will classify each page`
+            : mode === "auto"
+              ? "no training data selected yet"
+              : "no training data selected — the classifier opens with nothing pre-selected"}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/landing-page/src/components/project/ProjectDetail.tsx
+++ b/landing-page/src/components/project/ProjectDetail.tsx
@@ -5,6 +5,7 @@ import { getImageProgress, minNextStep } from "../../utils/imageStep";
 import { useAssetSection } from "../../hooks/useAssetSection";
 import type { useInferenceSettings } from "../../hooks/useInferenceSettings";
 import type { useTextFindingSettings } from "../../hooks/useTextFindingSettings";
+import type { useIcSettings } from "../../hooks/useIcSettings";
 import RenameModal from "./RenameModal";
 import DeleteProjectModal from "./DeleteProjectModal";
 import IcSessionsModal from "./IcSessionsModal";
@@ -81,6 +82,7 @@ interface ProjectDetailProps {
   onUpdateCantusSourceId: (sourceId: string) => void;
   inferenceSettings: ReturnType<typeof useInferenceSettings>;
   textFindingSettings: ReturnType<typeof useTextFindingSettings>;
+  icSettings: ReturnType<typeof useIcSettings>;
 }
 
 export default function ProjectDetail({
@@ -108,6 +110,7 @@ export default function ProjectDetail({
   onDeleteProject,
   inferenceSettings,
   textFindingSettings,
+  icSettings,
 }: ProjectDetailProps) {
   const [activeTab, setActiveTab] = useState<"images" | "models" | "generated">(
     "images",
@@ -201,6 +204,13 @@ export default function ProjectDetail({
     [usedNames.images, project.annotations, project.meiFiles, stepsUnlocked],
   );
   const sourceLocked = !(usedNames.images.length === 0 || nextStep === 0);
+  // Auto IC classifies server-side, which has no training pool without a
+  // training set - so Continue is greyed out until one is picked (or the mode
+  // is switched to manual). Gated on the steps that lead into IC, and checked
+  // at step 0 too: that step flows straight into step 1 in auto mode, so
+  // waiting until the IC step would waste a whole detection run.
+  const autoIcNeedsTraining =
+    nextStep <= 1 && icSettings.mode === "auto" && !icSettings.hasTrainingSet;
 
   const imgSection = useAssetSection(project.images);
   const mdlSection = useAssetSection(project.models);
@@ -701,6 +711,7 @@ export default function ProjectDetail({
               onBatchEndFolioChange={setBatchEndFolio}
               batchFolioSequence={batchFolioSequence}
               locked={sourceLocked}
+              icSettings={icSettings}
             />
             <div className="flex items-end">
               {tabs.map((tab, i) => (
@@ -905,9 +916,10 @@ export default function ProjectDetail({
                         }
                         setValidationError(null);
                       }
+                      if (autoIcNeedsTraining) return; // defensive; button is disabled below
                       onContinue();
                     }}
-                    disabled={!!activeJobForProject}
+                    disabled={!!activeJobForProject || autoIcNeedsTraining}
                     className="w-full px-5 py-2 bg-white text-[#4AADAA] font-semibold rounded-xl border-2 border-white hover:opacity-90 cursor-pointer flex items-center justify-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     {continueLabel} &rarr;
@@ -916,6 +928,12 @@ export default function ProjectDetail({
                     <p className="text-white/70 text-xs mt-1 text-center">
                       a {activeJobForProject.kind} job is already running for
                       this project — please wait for it to finish
+                    </p>
+                  )}
+                  {autoIcNeedsTraining && (
+                    <p className="text-white/70 text-xs mt-1 text-center">
+                      the classifier is set to auto — pick training data under
+                      "Classifier settings", or switch it to manual
                     </p>
                   )}
                 </>

--- a/landing-page/src/components/workflow/IcAutoQueue.tsx
+++ b/landing-page/src/components/workflow/IcAutoQueue.tsx
@@ -1,0 +1,196 @@
+import { useEffect, useRef, useState } from "react";
+import type { ProjectImage } from "../../types";
+import { autoQueueImage } from "../../utils/icQueue";
+import type { EncodePair } from "../../utils/icQueue";
+
+interface IcAutoQueueProps {
+  /** Only the pages step 1 still has work for — see pendingIcImages(). */
+  images: ProjectImage[];
+  /** Total pages selected on the project, pending or not — lets the empty
+   *  state tell "nothing selected yet" apart from "all already encoded". */
+  usedImageCount: number;
+  projectId: number | null;
+  trainingPresets: string[];
+  trainingFiles: File[];
+  onDone: (pairs: EncodePair[]) => void;
+  onBack: () => void;
+  /** Escape hatch to the interactive classifier — offered when the automatic
+   *  pass can't run (no training set) or fails partway. */
+  onOpenManualClassifier: () => void;
+}
+
+/**
+ * The "auto" IC mode: classify and queue every pending page with the training
+ * set picked on the project page (Classifier settings), then hand the queue
+ * to encoding. This is the old "queue all available" button from the IC
+ * page's filmstrip, run without ever showing the classifier interface.
+ *
+ * Pages are classified sequentially so the IC service isn't hammered and
+ * progress stays legible.
+ */
+export default function IcAutoQueue({
+  images,
+  usedImageCount,
+  projectId,
+  trainingPresets,
+  trainingFiles,
+  onDone,
+  onBack,
+  onOpenManualClassifier,
+}: IcAutoQueueProps) {
+  const [done, setDone] = useState(0);
+  const [current, setCurrent] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  // Bumped by "try again" to re-run the effect below.
+  const [attempt, setAttempt] = useState(0);
+  const hasTrainingSet = trainingPresets.length + trainingFiles.length > 0;
+  const canRun = projectId != null && images.length > 0 && hasTrainingSet;
+
+  // Guards the run against StrictMode's double-invoked effect (dev): the
+  // second invocation is skipped rather than firing a duplicate pass. Note
+  // this deliberately isn't a cleanup-driven cancel flag — StrictMode's
+  // simulated unmount would trip that and leave the run cancelled but never
+  // restarted. Real abandonment is handled by `abortedRef` on the back button.
+  const startedRef = useRef(-1);
+  const abortedRef = useRef(false);
+
+  useEffect(() => {
+    if (!canRun || startedRef.current === attempt) return;
+    startedRef.current = attempt;
+    (async () => {
+      const pairs: EncodePair[] = [];
+      try {
+        for (let i = 0; i < images.length; i++) {
+          if (abortedRef.current) return;
+          setCurrent(images[i].name);
+          pairs.push(
+            await autoQueueImage(
+              projectId,
+              images[i],
+              trainingPresets,
+              trainingFiles,
+            ),
+          );
+          setDone(i + 1);
+        }
+        if (!abortedRef.current) onDone(pairs);
+      } catch (err) {
+        if (!abortedRef.current)
+          setError(String((err as Error).message ?? err));
+      } finally {
+        setCurrent(null);
+      }
+    })();
+    // Re-runs only on an explicit retry; the deps this closure reads are all
+    // fixed for the lifetime of this view (it's mounted per IC-step entry).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [attempt, canRun]);
+
+  const handleBack = () => {
+    abortedRef.current = true;
+    onBack();
+  };
+
+  const pct = images.length > 0 ? Math.round((done / images.length) * 100) : 0;
+
+  return (
+    <div className="animate-fade-in flex-1 bg-[#4AADAA] flex flex-col items-center justify-center px-12 py-20 pb-48">
+      <div className="flex flex-col items-center gap-6 w-full max-w-xl">
+        <h1 className="text-4xl font-bold italic text-white text-center">
+          interactive classifier
+        </h1>
+
+        {images.length === 0 ? (
+          <>
+            <p className="text-[#1D3335] text-center">
+              {usedImageCount === 0
+                ? "no pages are selected for this project yet"
+                : `every selected page (${usedImageCount}) has already been classified and encoded`}
+            </p>
+            <p className="text-white/60 text-xs text-center max-w-md">
+              {usedImageCount === 0
+                ? "select images on the project page and run detection first."
+                : "there's nothing left to classify — carry on with correction (step 3), or select more pages on the project page."}
+            </p>
+          </>
+        ) : !hasTrainingSet ? (
+          <>
+            <p className="text-[#1D3335] text-center">
+              automatic classification needs a training set
+            </p>
+            <p className="text-white/70 text-sm text-center max-w-md">
+              pick a preset or upload GameraXML under "Classifier settings" on
+              the project page, or classify these {images.length} page
+              {images.length === 1 ? "" : "s"} yourself.
+            </p>
+          </>
+        ) : error ? (
+          <>
+            <p className="text-[#1D3335] text-center">
+              couldn't classify every page automatically
+            </p>
+            <p className="text-white/60 text-xs font-mono max-w-lg break-words text-center">
+              {error}
+            </p>
+            <p className="text-white/70 text-sm text-center">
+              {done} of {images.length} page{images.length === 1 ? "" : "s"}{" "}
+              finished before this — retrying starts the pass over.
+            </p>
+          </>
+        ) : (
+          <>
+            <p className="text-[#1D3335] text-center">
+              classifying and queuing every page with your training set
+            </p>
+            <div className="w-full h-2 bg-[#1D3335]/30 rounded-full overflow-hidden">
+              <div
+                className="h-full bg-white transition-all duration-300"
+                style={{ width: `${pct}%` }}
+              />
+            </div>
+            <p className="text-white/80 text-sm font-mono">
+              {done} / {images.length}
+              {current ? ` — ${current}` : ""}
+            </p>
+            <p className="text-white/50 text-xs text-center">
+              this runs the classifier for you — encoding starts automatically
+              when it's done.
+            </p>
+          </>
+        )}
+
+        <div className="flex items-center gap-4 flex-wrap justify-center">
+          {error && (
+            <button
+              onClick={() => {
+                setError(null);
+                setDone(0);
+                setAttempt((n) => n + 1);
+              }}
+              className="px-6 py-2 bg-white text-[#1D3335] rounded-xl hover:opacity-90 cursor-pointer font-semibold"
+            >
+              try again
+            </button>
+          )}
+          {images.length > 0 && (error || !hasTrainingSet) && (
+            <button
+              onClick={() => {
+                abortedRef.current = true;
+                onOpenManualClassifier();
+              }}
+              className="px-6 py-2 bg-[#1D3335] text-white border border-white/30 rounded-xl hover:opacity-90 cursor-pointer font-semibold"
+            >
+              classify manually
+            </button>
+          )}
+          <button
+            onClick={handleBack}
+            className="px-6 py-2 border-2 border-white text-white rounded-xl hover:bg-white/10 cursor-pointer font-semibold"
+          >
+            back to project
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/landing-page/src/components/workflow/InteractiveClassifier.tsx
+++ b/landing-page/src/components/workflow/InteractiveClassifier.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ProjectImage } from "../../types";
 import { apiFetch } from "../../lib/apiFetch";
+import { buildEncodePair } from "../../utils/icQueue";
 import { AuthImage } from "../shared/AuthImage";
 
 interface InteractiveClassifierProps {
@@ -21,9 +22,14 @@ interface InteractiveClassifierProps {
   onClefShapeChange: (s: "C" | "F") => void;
   clefLine: number;
   onClefLineChange: (n: number) => void;
+  // Training set picked on the project page ("Classifier settings").
+  // Pre-selected in
+  // each page's IC create-session screen via the ic:prefill-training reply
+  // below; empty when the user made no choice there, in which case the
+  // classifier opens with nothing pre-selected (its own default).
+  trainingPresets: string[];
+  trainingFiles: File[];
 }
-
-const stemOf = (name: string) => name.replace(/\.[^.]+$/, "");
 
 export default function InteractiveClassifier({
   images,
@@ -36,6 +42,8 @@ export default function InteractiveClassifier({
   onClefShapeChange,
   clefLine,
   onClefLineChange,
+  trainingPresets,
+  trainingFiles,
 }: InteractiveClassifierProps) {
   // Resolved once, at mount: this view is remounted on every entry (AppRouter
   // switches on `view`), and after that the filmstrip owns the selection - a
@@ -61,37 +69,18 @@ export default function InteractiveClassifier({
   // click on that path, so we run the queue logic ourselves once state settles.
   const [autoQueueRequested, setAutoQueueRequested] = useState(false);
 
-  // Shared training set (built-in presets + uploaded GameraXML) applied to
-  // every page by "queue all available" — picked once at the parent level so
-  // the user doesn't re-select it in each page's IC iframe.
-  const [availablePresets, setAvailablePresets] = useState<string[]>([]);
-  const [trainingPresets, setTrainingPresets] = useState<string[]>([]);
-  const [trainingFiles, setTrainingFiles] = useState<File[]>([]);
-  const [showTrainingPanel, setShowTrainingPanel] = useState(false);
-  // Progress of a "queue all available" run: null when idle.
-  const [queueAll, setQueueAll] = useState<{
-    done: number;
-    total: number;
-  } | null>(null);
-  // Bumped to force the IC iframe to remount (and re-run its ic:ready
-  // handshake) when the batch training set changes while a create-session page
-  // is open — see the reload effect below.
-  const [reloadNonce, setReloadNonce] = useState(0);
-
   const queuedNames = useMemo(
     () => new Set(queue.map((p) => p.imageFile.name)),
     [queue],
   );
-  const totalTrainingSets = trainingPresets.length + trainingFiles.length;
-  const unqueuedCount = images.filter((im) => !queuedNames.has(im.name)).length;
 
   const img = images[currentIdx];
   // Guards against a slow /ic/start response landing after the user has
   // already switched pages — only the latest request may set state.
   const startSeq = useRef(0);
 
-  // Latest batch training selection, readable from the message handler below
-  // without re-subscribing the listener whenever the selection changes.
+  // Training selection from the project page, readable from the message
+  // handler below without re-subscribing the listener when it changes.
   const trainingRef = useRef({
     presets: trainingPresets,
     files: trainingFiles,
@@ -99,17 +88,6 @@ export default function InteractiveClassifier({
   useEffect(() => {
     trainingRef.current = { presets: trainingPresets, files: trainingFiles };
   }, [trainingPresets, trainingFiles]);
-
-  // Reload the iframe once if a create-session page is currently open (staged,
-  // no session started yet) so a just-changed batch training set shows there
-  // immediately — the remount re-runs the ic:ready handshake and re-pulls the
-  // selection. Called from the training-set handlers rather than an effect so
-  // it only fires on a real user change (not page navigation, which already
-  // remounts the iframe via icUrl) and stays out of the resumed/live-session
-  // case (sessionId set), where reloading would blow away in-progress work.
-  const reloadOpenCreateSession = useCallback(() => {
-    if (icUrl && sessionId == null) setReloadNonce((n) => n + 1);
-  }, [icUrl, sessionId]);
 
   // Stage a fresh page + bboxes in IC whenever the selected page changes.
   useEffect(() => {
@@ -155,9 +133,9 @@ export default function InteractiveClassifier({
       if (icOrigin && e.origin !== icOrigin) return;
       const data = e.data;
       // The embedded create-session screen announces readiness; reply with the
-      // batch-level training set (if any) so the user doesn't have to re-pick
-      // it on every page. The iframe seeds its own inputs from this and won't
-      // overwrite a selection already made there.
+      // project-level training set (if any) so the user doesn't have to
+      // re-pick it on every page. The iframe seeds its own inputs from this
+      // and won't overwrite a selection already made there.
       if (data?.type === "ic:ready") {
         const { presets, files } = trainingRef.current;
         if (presets.length > 0 || files.length > 0) {
@@ -190,46 +168,6 @@ export default function InteractiveClassifier({
     return () => window.removeEventListener("message", onMessage);
   }, [icOrigin]);
 
-  // Load the built-in training-set presets once so the parent-level picker can
-  // offer the same list IC's create-session screen shows.
-  useEffect(() => {
-    apiFetch("/api/ic/training-presets")
-      .then((r) => (r.ok ? r.json() : []))
-      .then((list) => setAvailablePresets(Array.isArray(list) ? list : []))
-      .catch(() => setAvailablePresets([]));
-  }, []);
-
-  // Presets are mutually exclusive here for the same reason they are in the
-  // IC iframe's own picker: checking one unchecks the rest. Kept as an array
-  // because the batch prefill and the API both take a list, and an uploaded
-  // set can still be combined with a preset — only preset-vs-preset is
-  // exclusive.
-  const togglePreset = (name: string, checked: boolean) => {
-    setTrainingPresets(checked ? [name] : []);
-    reloadOpenCreateSession();
-  };
-
-  // Turn IC's GameraXML (base64) + a project image into the {xmlFile, imageFile}
-  // pair the encode-batch flow consumes. Shared by the interactive "queue page"
-  // and the batch "queue all available" paths.
-  const buildPair = useCallback(
-    async (image: ProjectImage, xmlBase64: string) => {
-      const xmlBytes = Uint8Array.from(atob(xmlBase64), (c) => c.charCodeAt(0));
-      const xmlFile = new File([xmlBytes], `${stemOf(image.name)}.xml`, {
-        type: "application/xml",
-      });
-      const imgResp = await apiFetch(`/api/images/${image.id}`);
-      if (!imgResp.ok)
-        throw new Error(`image fetch failed (${imgResp.status})`);
-      const blob = await imgResp.blob();
-      const imageFile = new File([blob], image.name, {
-        type: blob.type || "image/png",
-      });
-      return { xmlFile, imageFile };
-    },
-    [],
-  );
-
   const handleQueuePage = useCallback(async () => {
     if (!sessionId || !img) return;
     setEncoding(true);
@@ -245,7 +183,7 @@ export default function InteractiveClassifier({
 
       // 2. Build the pair and hand it to the encode flow; advance to the next
       //    un-queued page.
-      const pair = await buildPair(img, data.xml_base64);
+      const pair = await buildEncodePair(img, data.xml_base64);
       setQueue((prev) => [...prev, pair]);
       const nextIdx = images.findIndex(
         (im, idx) => idx > currentIdx && !queuedNames.has(im.name),
@@ -256,55 +194,7 @@ export default function InteractiveClassifier({
     } finally {
       setEncoding(false);
     }
-  }, [sessionId, img, buildPair, images, currentIdx, queuedNames]);
-
-  // "Queue all available": classify every not-yet-queued page with the shared
-  // training set (server-side, no per-page iframe) and add each to the encode
-  // queue. Runs sequentially so the IC service isn't hammered and progress is
-  // legible. Requires a non-empty training set (classify needs a training pool).
-  const handleQueueAll = useCallback(async () => {
-    if (projectId == null || totalTrainingSets === 0) return;
-    const pending = images.filter((im) => !queuedNames.has(im.name));
-    if (pending.length === 0) return;
-    setError(null);
-    setQueueAll({ done: 0, total: pending.length });
-    try {
-      for (let i = 0; i < pending.length; i++) {
-        const image = pending[i];
-        const form = new FormData();
-        form.append("imageName", image.name);
-        if (trainingPresets.length > 0)
-          form.append("training_presets", JSON.stringify(trainingPresets));
-        trainingFiles.forEach((f) => form.append("training_files", f));
-        const r = await apiFetch(`/api/projects/${projectId}/ic/auto-queue`, {
-          method: "POST",
-          body: form,
-        });
-        if (!r.ok)
-          throw new Error(await r.text().catch(() => `HTTP ${r.status}`));
-        const data = await r.json();
-        const pair = await buildPair(image, data.xml_base64);
-        setQueue((prev) =>
-          prev.some((p) => p.imageFile.name === pair.imageFile.name)
-            ? prev
-            : [...prev, pair],
-        );
-        setQueueAll({ done: i + 1, total: pending.length });
-      }
-    } catch (err) {
-      setError(String((err as Error).message ?? err));
-    } finally {
-      setQueueAll(null);
-    }
-  }, [
-    projectId,
-    totalTrainingSets,
-    images,
-    queuedNames,
-    trainingPresets,
-    trainingFiles,
-    buildPair,
-  ]);
+  }, [sessionId, img, images, currentIdx, queuedNames]);
 
   // Run the queue path for an auto-exported page once the session id and
   // current page have settled. Gated on the flag (reset immediately) so it
@@ -367,93 +257,6 @@ export default function InteractiveClassifier({
             onChange={(e) => onClefLineChange(Number(e.target.value))}
             className="w-10 bg-transparent border border-white/30 rounded px-1 text-sm text-center text-white"
           />
-        </div>
-
-        {/* Shared training set picker — presets + uploaded GameraXML applied
-            to every page by "queue all available". */}
-        <div className="relative">
-          <button
-            onClick={() => setShowTrainingPanel((v) => !v)}
-            className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-white/30 text-white text-sm hover:bg-white/10 cursor-pointer"
-          >
-            training set
-            {totalTrainingSets > 0 && (
-              <span className="bg-white text-[#1D3335] rounded-full px-1.5 text-xs font-semibold">
-                {totalTrainingSets}
-              </span>
-            )}
-          </button>
-          {showTrainingPanel && (
-            <>
-              <div
-                className="fixed inset-0 z-40"
-                onClick={() => setShowTrainingPanel(false)}
-              />
-              <div className="absolute z-50 top-full mt-2 left-0 w-80 bg-white rounded-xl shadow-2xl p-4 text-[#1D3335] text-sm">
-                <h3 className="font-semibold">training set for all pages</h3>
-                <p className="text-xs text-[#1D3335]/60 mb-3">
-                  Applied to every page when you "queue all available".
-                </p>
-
-                <div className="mb-3">
-                  <span className="mb-1 block text-xs font-medium text-[#1D3335]/70">
-                    Presets
-                  </span>
-                  {availablePresets.length === 0 ? (
-                    <span className="text-xs text-[#1D3335]/50">
-                      No presets available.
-                    </span>
-                  ) : (
-                    <div className="space-y-1 max-h-40 overflow-y-auto">
-                      {availablePresets.map((name) => (
-                        <label
-                          key={name}
-                          className="flex items-center gap-2 cursor-pointer"
-                        >
-                          <input
-                            type="checkbox"
-                            checked={trainingPresets.includes(name)}
-                            onChange={(e) =>
-                              togglePreset(name, e.target.checked)
-                            }
-                          />
-                          <span className="truncate">{name}</span>
-                        </label>
-                      ))}
-                    </div>
-                  )}
-                </div>
-
-                <label className="block">
-                  <span className="mb-1 block text-xs font-medium text-[#1D3335]/70">
-                    Upload GameraXML (.xml)
-                  </span>
-                  <input
-                    type="file"
-                    accept=".xml"
-                    multiple
-                    onChange={(e) => {
-                      setTrainingFiles(Array.from(e.target.files ?? []));
-                      reloadOpenCreateSession();
-                    }}
-                    className="block w-full text-xs text-[#1D3335]/70 file:mr-2 file:cursor-pointer file:rounded-lg file:border-0 file:bg-[#4AADAA] file:px-3 file:py-1.5 file:text-xs file:font-semibold file:text-white hover:file:opacity-90"
-                  />
-                </label>
-                {trainingFiles.length > 0 && (
-                  <span className="mt-1 block text-xs text-[#1D3335]/60">
-                    {trainingFiles.length} file
-                    {trainingFiles.length === 1 ? "" : "s"} selected
-                  </span>
-                )}
-
-                <p className="mt-3 text-xs text-[#1D3335]/60">
-                  {totalTrainingSets > 0
-                    ? `${totalTrainingSets} training set${totalTrainingSets === 1 ? "" : "s"} will classify each page.`
-                    : "Pick presets or upload sets to enable queue all."}
-                </p>
-              </div>
-            </>
-          )}
         </div>
 
         <div className="flex-1" />
@@ -534,7 +337,7 @@ export default function InteractiveClassifier({
             </div>
           ) : icUrl ? (
             <iframe
-              key={`${icUrl}:${reloadNonce}`}
+              key={icUrl}
               src={icUrl}
               title={`Interactive Classifier — ${img?.name ?? ""}`}
               className="flex-1 w-full border-0"
@@ -548,9 +351,7 @@ export default function InteractiveClassifier({
 
         {/* filmstrip for page selection */}
         {images.length > 1 && (
-          <div className="flex items-center px-6 pb-2 pt-2 gap-4">
-            {/* left spacer keeps the thumbnails centered opposite the button */}
-            <div className="flex-1" />
+          <div className="flex items-center justify-center px-6 pb-2 pt-2 gap-4">
             <div className="flex items-center justify-center gap-3">
               <button
                 onClick={() => setCurrentIdx((i) => i - 1)}
@@ -589,29 +390,6 @@ export default function InteractiveClassifier({
                 className="text-white text-xl hover:opacity-70 disabled:opacity-20 cursor-pointer"
               >
                 &gt;
-              </button>
-            </div>
-            {/* queue every not-yet-queued page with the shared training set */}
-            <div className="flex-1 flex justify-end">
-              <button
-                onClick={handleQueueAll}
-                disabled={
-                  queueAll !== null ||
-                  totalTrainingSets === 0 ||
-                  unqueuedCount === 0
-                }
-                title={
-                  totalTrainingSets === 0
-                    ? "Pick a training set first (top bar)"
-                    : unqueuedCount === 0
-                      ? "Every page is already queued"
-                      : "Classify and queue every remaining page with the training set"
-                }
-                className="px-4 py-1.5 bg-white text-[#1D3335] rounded-lg text-sm font-semibold hover:opacity-90 cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed whitespace-nowrap"
-              >
-                {queueAll
-                  ? `queuing ${queueAll.done}/${queueAll.total}…`
-                  : `queue all available (${unqueuedCount})`}
               </button>
             </div>
           </div>

--- a/landing-page/src/hooks/useIcSettings.ts
+++ b/landing-page/src/hooks/useIcSettings.ts
@@ -1,0 +1,42 @@
+import { useState } from "react";
+
+export type IcMode = "auto" | "manual";
+
+export interface IcSettings {
+  /** "auto" skips the classifier interface entirely — every page is
+   *  classified and queued with the training set below. "manual" opens the
+   *  classifier and only pre-selects that training set on each page. */
+  mode: IcMode;
+  trainingPresets: string[];
+  trainingFiles: File[];
+}
+
+/**
+ * IC step settings, picked on the project page (see IcSettingsSection) and
+ * consumed by both IC routes. Application-level state, like
+ * useInferenceSettings/useTextFindingSettings — not persisted per project
+ * (uploaded training files are in-memory File objects, so a DB-backed
+ * selection couldn't round-trip them anyway).
+ */
+export function useIcSettings() {
+  // Defaults to "auto" - the hands-off path is the intended default for the
+  // IC step. Note this makes training data effectively required up front: the
+  // auto pass can't classify without one, so ProjectDetail blocks Continue
+  // until the user picks one here or switches to manual.
+  const [mode, setMode] = useState<IcMode>("auto");
+  const [trainingPresets, setTrainingPresets] = useState<string[]>([]);
+  const [trainingFiles, setTrainingFiles] = useState<File[]>([]);
+
+  return {
+    mode,
+    setMode,
+    trainingPresets,
+    setTrainingPresets,
+    trainingFiles,
+    setTrainingFiles,
+    // "the user made a settings choice" — what gates auto mode (classify
+    // needs a non-empty training pool) and what decides whether the manual
+    // classifier gets a prefill at all.
+    hasTrainingSet: trainingPresets.length + trainingFiles.length > 0,
+  };
+}

--- a/landing-page/src/types.ts
+++ b/landing-page/src/types.ts
@@ -114,6 +114,7 @@ export type View =
   | "processing"
   | "completion"
   | "ic"
+  | "ic-auto"
   | "ic-completion"
   | "encoding-processing"
   | "encoding-completion"

--- a/landing-page/src/utils/icQueue.ts
+++ b/landing-page/src/utils/icQueue.ts
@@ -1,0 +1,56 @@
+import { apiFetch } from "../lib/apiFetch";
+import type { ProjectImage } from "../types";
+
+/** The {xmlFile, imageFile} shape the encode-batch flow consumes. */
+export interface EncodePair {
+  xmlFile: File;
+  imageFile: File;
+}
+
+const stemOf = (name: string) => name.replace(/\.[^.]+$/, "");
+
+/**
+ * Turn IC's GameraXML (base64) + a project image into an encode pair. Shared
+ * by the interactive "queue page" path and the automatic queue-all path.
+ */
+export async function buildEncodePair(
+  image: ProjectImage,
+  xmlBase64: string,
+): Promise<EncodePair> {
+  const xmlBytes = Uint8Array.from(atob(xmlBase64), (c) => c.charCodeAt(0));
+  const xmlFile = new File([xmlBytes], `${stemOf(image.name)}.xml`, {
+    type: "application/xml",
+  });
+  const imgResp = await apiFetch(`/api/images/${image.id}`);
+  if (!imgResp.ok) throw new Error(`image fetch failed (${imgResp.status})`);
+  const blob = await imgResp.blob();
+  const imageFile = new File([blob], image.name, {
+    type: blob.type || "image/png",
+  });
+  return { xmlFile, imageFile };
+}
+
+/**
+ * Classify one page server-side with the shared training set (no IC iframe)
+ * and return its encode pair. Requires a non-empty training set — classify
+ * has no training pool without one.
+ */
+export async function autoQueueImage(
+  projectId: number,
+  image: ProjectImage,
+  trainingPresets: string[],
+  trainingFiles: File[],
+): Promise<EncodePair> {
+  const form = new FormData();
+  form.append("imageName", image.name);
+  if (trainingPresets.length > 0)
+    form.append("training_presets", JSON.stringify(trainingPresets));
+  trainingFiles.forEach((f) => form.append("training_files", f));
+  const r = await apiFetch(`/api/projects/${projectId}/ic/auto-queue`, {
+    method: "POST",
+    body: form,
+  });
+  if (!r.ok) throw new Error(await r.text().catch(() => `HTTP ${r.status}`));
+  const data = await r.json();
+  return buildEncodePair(image, data.xml_base64);
+}


### PR DESCRIPTION
The interactive classifier page carried two controls that only make sense *before* you start classifying: a "training set" popover in its top bar and a "queue all available" button in its filmstrip. Both now live on the project page, in a new "Classifier settings" column beside the (newly headed) "CantusDB settings" column — so the choice is made once, alongside image and model selection, instead of mid-classification. The preset list and the GameraXML upload are laid out in place rather than behind another popover.

The auto/manual switch there decides what step 1 does:

- **auto** (the default) — no classifier interface at all. The new `ic-auto` view classifies and queues every pending page through `/api/projects/{id}/ic/auto-queue` (the same endpoint and the same sequential pass the old "queue all available" ran), then hands the queue straight to encoding. It shows a progress bar, since a multi-page pass takes a while and silence reads as a hang.
- **manual** — the classifier as before, except the training data picked on the project page is pre-selected on each page via the existing `ic:prefill-training` postMessage. Picked nothing? No prefill is sent, and the classifier keeps its own defaults.

Because auto has no training pool to classify against without a training set, Continue is greyed out — with the reason underneath it — at the steps leading into IC. That includes step 0, which flows straight into step 1 in auto mode, so waiting until the IC step would waste a whole detection run. **Worth knowing on review:** with auto as the default, picking training data is now effectively a required step for a brand-new project. Resuming a saved session from "manage IC sessions" still opens the classifier regardless of mode, since the user picked that session explicitly.

Settings live in `useIcSettings` at application level, matching `useInferenceSettings`/`useTextFindingSettings`. They are deliberately not persisted per project: uploaded training files are in-memory `File` objects, so a DB-backed selection couldn't round-trip them anyway.

One note for reading the diff — `CantusSourcePanel.tsx` shows ~300 changed lines, but most of that is Prettier re-indenting the existing Cantus block after it was wrapped in a column `div`. The real changes there are the two-column layout, the new section header, and mounting `IcSettingsSection`.

Verified with `tsc`, `eslint` (no new findings against baseline), and `vite build`. The auto pass has not been exercised end-to-end against a running IC service — it reuses the already-working `/ic/auto-queue` call path, but that's the gap to poke at when testing this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added project-level Interactive Classifier settings with automatic and manual modes.
  - Added support for selecting training presets and uploading multiple training files.
  - Added automatic sequential classification and encoding of project images, with progress reporting and manual fallback.
  - Added a dedicated automatic classification workflow view.
- **Bug Fixes**
  - Prevented workflows from continuing into automatic classification without required training data.
  - Improved handling of classification failures, retries, cancellations, and resumed sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->