### PR TITLE
features: viewing/cancelling jobs from the projectdetail page, improving "view" on the popup toasts

### DIFF
--- a/landing-page/scripts/job_store.py
+++ b/landing-page/scripts/job_store.py
@@ -70,7 +70,11 @@ def claim_project_job(project_id: int, kind: str, *, job_id: str,
     Returns (job_id_to_use, is_new, active_job). `active_job` is set (and
     job_id_to_use is None) when a job of a kind NOT in `allowed_kinds`
     (defaults to just `kind` itself) is already active -- callers should
-    raise 409 using it, same shape get_active_job_for_project returned.
+    raise 409 using it. Unlike get_active_job_for_project's {"job_id",
+    "kind", "status"}, this active_job has no "status" key -- every caller
+    of this function only ever reads "job_id"/"kind" out of it for the 409
+    message, so it was never added here.
+
     Otherwise behaves like create_job: `is_new` indicates whether the
     caller should actually enqueue a Celery task, and dedupe_seconds keeps
     its original meaning (collapse an exact same-kind duplicate kickoff
@@ -119,8 +123,9 @@ def claim_project_job(project_id: int, kind: str, *, job_id: str,
         release_db_conn(con)
 
 def get_active_job_for_project(project_id: int) -> Optional[dict]:
-    """Returns {"job_id": ..., "kind": ...} for the most recent pending/running
-    job for this project, across ALL kinds, or None if there isn't one.
+    """Returns {"job_id": ..., "kind": ..., "status": ...} for the most recent
+    pending/running job for this project, across ALL kinds, or None if there
+    isn't one.
 
     Unlike create_job's dedupe_seconds (scoped to kind+project_id, and only a
     few-second window — meant to collapse an exact duplicate kickoff, e.g. a

--- a/landing-page/scripts/job_store.py
+++ b/landing-page/scripts/job_store.py
@@ -139,14 +139,14 @@ def get_active_job_for_project(project_id: int) -> Optional[dict]:
     try:
         cur = con.cursor()
         cur.execute(
-            "SELECT job_id, kind FROM jobs WHERE project_id=%s"
+            "SELECT job_id, kind, status FROM jobs WHERE project_id=%s"
             " AND status IN ('pending','running')"
             " ORDER BY created_at DESC LIMIT 1",
             (project_id,),
         )
         row = cur.fetchone()
         cur.close()
-        return {"job_id": row[0], "kind": row[1]} if row else None
+        return {"job_id": row[0], "kind": row[1], "status": row[2]} if row else None
     finally:
         release_db_conn(con)
 

--- a/landing-page/scripts/projects_api.py
+++ b/landing-page/scripts/projects_api.py
@@ -17,6 +17,7 @@ import uuid as _uuid
 import zipfile
 
 from auth_api import get_current_user, db_cursor, require_project_owner, _log_activity, MODELS_DIR
+from job_store import get_active_job_for_project
 
 router = APIRouter()
 
@@ -226,6 +227,20 @@ def get_activity(project_id: int, user=Depends(get_current_user)):
         )
         return [{"actionType": r[0], "detail": r[1], "createdAt": str(r[2])} for r in cur.fetchall()]
 
+@router.get("/projects/{project_id}/active-job")
+def get_project_active_job(project_id: int, user=Depends(get_current_user)):
+    """Exposes job_store.get_active_job_for_project over HTTP so the project
+    page can discover a still-running predict/encode/text-batch job after a
+    reload or from a different tab than the one that kicked it off --
+    activeJobs.ts's in-memory registry only covers the same-tab session that
+    actually called the kickoff endpoint. Returns null when nothing is
+    currently pending/running for this project."""
+    with db_cursor() as (con, cur):
+        require_project_owner(cur, project_id, user["id"])
+    active = get_active_job_for_project(project_id)
+    if active is None:
+        return None
+    return {"job_id": active["job_id"], "kind": active["kind"], "status": active["status"]}
 
 class CreateProjectBody(BaseModel):
     name: str

--- a/landing-page/scripts/projects_api.py
+++ b/landing-page/scripts/projects_api.py
@@ -235,7 +235,7 @@ def get_project_active_job(project_id: int, user=Depends(get_current_user)):
     activeJobs.ts's in-memory registry only covers the same-tab session that
     actually called the kickoff endpoint. Returns null when nothing is
     currently pending/running for this project."""
-    with db_cursor() as (con, cur):
+    with db_cursor() as (_con, cur):
         require_project_owner(cur, project_id, user["id"])
     active = get_active_job_for_project(project_id)
     if active is None:

--- a/landing-page/src/App.tsx
+++ b/landing-page/src/App.tsx
@@ -3,7 +3,7 @@ import Navbar from "./components/layout/Navbar";
 import Footer from "./components/layout/Footer";
 import AppRouter from "./components/AppRouter";
 import ToastContainer from "./components/shared/ToastContainer";
-import type { View, Project } from "./types";
+import type { View, Project, ProjectInitialTab } from "./types";
 import type { CurrentUser } from "./hooks/useAuth";
 import { getToken, setToken, clearToken } from "./hooks/useAuth";
 import { normalizeProjects } from "./utils/projects";
@@ -14,6 +14,38 @@ import { apiFetch, registerUnauthenticatedHandler } from "./lib/apiFetch";
 import { useActiveJobWatcher } from "./hooks/useActiveJobWatcher";
 import { toast } from "./lib/toast";
 
+// Where a job-done toast's "view" button should actually land (issue #196):
+// - succeeded: the tab holding what the job produced.
+// - failed/cancelled, for a kind resumeJob knows how to reattach to
+//   (see AppRouter.tsx's case "processing"): reopen ProcessingPage on the
+//   job's own stream, which replays its full history including the error.
+// encode_upload/encode_batch failures have no resume path yet (same
+// deliberate limit as issue #195's ProjectDetail "view progress" -- see
+// AppRouter.tsx) and fall through to just landing on the project page.
+const RESUMABLE_JOB_KINDS = new Set(["predict", "text_batch"]);
+const SUCCESS_TAB_BY_JOB_KIND: Record<string, ProjectInitialTab> = {
+  predict: { tab: "generated", subTab: "annotations" },
+  text_batch: { tab: "generated", subTab: "text" },
+  encode_upload: { tab: "generated", subTab: "mei files" },
+  encode_batch: { tab: "generated", subTab: "mei files" },
+};
+
+// The stepsUnlocked floor a succeeded job of this kind guarantees -- mirrors
+// what AppRouter.tsx's ProcessingPage onComplete handlers already bump to
+// when the user is actively watching (Math.max(current, N)). Needed because
+// getImageProgress (utils/imageStep.ts) gates its "ic" step behind
+// `stepsUnlocked >= 1`, so if nobody's ProcessingPage was mounted to run
+// that onComplete -- e.g. the user stayed on the project page the whole
+// time a job ran instead of watching it finish -- stepsUnlocked (and the
+// project's own annotations/meiFiles) never advance, and the "begin" button
+// stays stuck forever even though the job actually succeeded server-side.
+const STEPS_UNLOCKED_BY_JOB_KIND: Record<string, number> = {
+  predict: 1,
+  text_batch: 1,
+  encode_upload: 3,
+  encode_batch: 3,
+};
+
 export default function App() {
   const [view, setView] = useState<View>("landing");
   const [currentUser, setCurrentUser] = useState<CurrentUser | null>(null);
@@ -21,10 +53,17 @@ export default function App() {
   const [selectedProjectId, setSelectedProjectId] = useState<number | null>(
     null,
   );
+  const [resumeJob, setResumeJob] = useState<{
+    jobId: string;
+    kind: string;
+  } | null>(null);
+  const [pendingProjectTab, setPendingProjectTab] =
+    useState<ProjectInitialTab | null>(null);
 
   const selectedProject =
     projects.find((p) => p.id === selectedProjectId) ?? null;
   const mutations = useProjectMutations(setProjects);
+  const { updateProjectSteps } = mutations;
 
   // Browser back/forward should step through Mothra's own view history
   // instead of leaving the app on the first Back press (issue #133). There's
@@ -83,6 +122,31 @@ export default function App() {
   useScrollFade(view);
 
   useActiveJobWatcher((job, status) => {
+    if (status === "succeeded" && job.projectId != null) {
+      const projectId = job.projectId;
+      // Refresh this project's data + bump stepsUnlocked regardless of
+      // whether anyone's ProcessingPage is actually mounted watching this
+      // job right now -- this is the only path that does so for a job that
+      // finishes while the user just sat on the project page instead of
+      // watching it (AppRouter.tsx's onResult/onComplete only run for a
+      // mounted ProcessingPage, and there's real overlap when one *is*
+      // mounted, but both ends up idempotent).
+      apiFetch(`/api/projects/${projectId}`)
+        .then((r) => (r.ok ? r.json() : null))
+        .then((fresh: Project | null) => {
+          if (!fresh) return;
+          const [normalized] = normalizeProjects([fresh]);
+          setProjects((prev) =>
+            prev.map((p) => (p.id === normalized.id ? normalized : p)),
+          );
+        })
+        .catch(() => {});
+      const minSteps = STEPS_UNLOCKED_BY_JOB_KIND[job.kind];
+      const current = projects.find((p) => p.id === projectId);
+      if (minSteps != null && current) {
+        updateProjectSteps(projectId, Math.max(current.stepsUnlocked, minSteps));
+      }
+    }
     toast[
       status === "succeeded"
         ? "success"
@@ -95,7 +159,18 @@ export default function App() {
         label: "view",
         onClick: () => {
           if (job.projectId) setSelectedProjectId(job.projectId);
-          setView("project");
+          if (status === "succeeded") {
+            setPendingProjectTab(SUCCESS_TAB_BY_JOB_KIND[job.kind] ?? null);
+            setView("project");
+          } else if (
+            (status === "failed" || status === "cancelled") &&
+            RESUMABLE_JOB_KINDS.has(job.kind)
+          ) {
+            setResumeJob({ jobId: job.jobId, kind: job.kind });
+            setView("processing");
+          } else {
+            setView("project");
+          }
         },
       },
     });
@@ -173,6 +248,10 @@ export default function App() {
         handleEncodeResult={handleEncodeResult}
         pendingBatchPairs={pendingBatchPairs}
         setPendingBatchPairs={setPendingBatchPairs}
+        resumeJob={resumeJob}
+        setResumeJob={setResumeJob}
+        pendingProjectTab={pendingProjectTab}
+        setPendingProjectTab={setPendingProjectTab}
         handleEncodeBatchResult={handleEncodeBatchResult}
       />
       <Footer />

--- a/landing-page/src/App.tsx
+++ b/landing-page/src/App.tsx
@@ -130,7 +130,14 @@ export default function App() {
       // finishes while the user just sat on the project page instead of
       // watching it (AppRouter.tsx's onResult/onComplete only run for a
       // mounted ProcessingPage, and there's real overlap when one *is*
-      // mounted, but both ends up idempotent).
+      // mounted, but both end up idempotent).
+      //
+      // The stepsUnlocked bump is chained AFTER the refetch resolves and
+      // floored against the server's own just-fetched value (normalized.
+      // stepsUnlocked), not fired concurrently against a possibly-stale
+      // `projects` closure -- firing both at once let an in-flight GET that
+      // started before the PUT resolve AFTER it and overwrite the
+      // just-bumped local stepsUnlocked back down to its pre-bump value.
       apiFetch(`/api/projects/${projectId}`)
         .then((r) => (r.ok ? r.json() : null))
         .then((fresh: Project | null) => {
@@ -139,13 +146,15 @@ export default function App() {
           setProjects((prev) =>
             prev.map((p) => (p.id === normalized.id ? normalized : p)),
           );
+          const minSteps = STEPS_UNLOCKED_BY_JOB_KIND[job.kind];
+          if (minSteps != null) {
+            updateProjectSteps(
+              projectId,
+              Math.max(normalized.stepsUnlocked, minSteps),
+            );
+          }
         })
         .catch(() => {});
-      const minSteps = STEPS_UNLOCKED_BY_JOB_KIND[job.kind];
-      const current = projects.find((p) => p.id === projectId);
-      if (minSteps != null && current) {
-        updateProjectSteps(projectId, Math.max(current.stepsUnlocked, minSteps));
-      }
     }
     toast[
       status === "succeeded"

--- a/landing-page/src/components/AppRouter.tsx
+++ b/landing-page/src/components/AppRouter.tsx
@@ -6,6 +6,7 @@ import type {
   AnnotationSet,
   MeiFile,
   ModelKind,
+  ProjectInitialTab,
 } from "../types";
 import type { CurrentUser } from "../hooks/useAuth";
 import { apiFetch, apiFetchOrThrow, apiFetchJobStream } from "../lib/apiFetch";
@@ -102,6 +103,10 @@ interface AppRouterProps {
   }) => void;
   pendingBatchPairs: { xmlFile: File; imageFile: File }[];
   setPendingBatchPairs: (pairs: { xmlFile: File; imageFile: File }[]) => void;
+  resumeJob: { jobId: string; kind: string } | null;
+  setResumeJob: (job: { jobId: string; kind: string } | null) => void;
+  pendingProjectTab: ProjectInitialTab | null;
+  setPendingProjectTab: (tab: ProjectInitialTab | null) => void;
   handleEncodeBatchResult: (ev: {
     item: number;
     session_id: string;
@@ -137,6 +142,10 @@ export default function AppRouter({
   handleEncodeResult,
   pendingBatchPairs,
   setPendingBatchPairs,
+  resumeJob,
+  setResumeJob,
+  pendingProjectTab,
+  setPendingProjectTab,
   handleEncodeBatchResult,
 }: AppRouterProps) {
   const {
@@ -165,14 +174,6 @@ export default function AppRouter({
   const [batchRunIds, setBatchRunIds] = useState<{
     imageIds: string[];
     folios: string[];
-  } | null>(null);
-  // Set when the user clicks "view progress" on the project page for a job
-  // this tab didn't kick off itself (ProjectDetail.tsx's onViewActiveJob) --
-  // tells the "processing" case below to reattach ProcessingPage to an
-  // existing job_id's stream instead of running its normal kickoff.
-  const [resumeJob, setResumeJob] = useState<{
-    jobId: string;
-    kind: string;
   } | null>(null);
   const [batchResult, setBatchResult] = useState<{
     batchId: string;
@@ -359,6 +360,8 @@ export default function AppRouter({
             setResumeJob({ jobId, kind });
             setView("processing");
           }}
+          initialTab={pendingProjectTab}
+          onInitialTabConsumed={() => setPendingProjectTab(null)}
           sendingBundle={sendingBundle}
           sendBundleError={sendBundleError}
           onRenameProject={(newName) =>
@@ -486,6 +489,7 @@ export default function AppRouter({
           }}
           projectId={selectedProject.id}
           jobKind={resumeJob?.kind ?? (batchRunIds ? "text_batch" : "predict")}
+          initialLogsOpen={!!resumeJob}
           streamRequest={
             resumeJob
               ? (signal, onJobId) => {

--- a/landing-page/src/components/AppRouter.tsx
+++ b/landing-page/src/components/AppRouter.tsx
@@ -166,6 +166,14 @@ export default function AppRouter({
     imageIds: string[];
     folios: string[];
   } | null>(null);
+  // Set when the user clicks "view progress" on the project page for a job
+  // this tab didn't kick off itself (ProjectDetail.tsx's onViewActiveJob) --
+  // tells the "processing" case below to reattach ProcessingPage to an
+  // existing job_id's stream instead of running its normal kickoff.
+  const [resumeJob, setResumeJob] = useState<{
+    jobId: string;
+    kind: string;
+  } | null>(null);
   const [batchResult, setBatchResult] = useState<{
     batchId: string;
     fileCount: number;
@@ -347,6 +355,10 @@ export default function AppRouter({
             setView("ic");
           }}
           onSendToCantus={handleSendToCantus}
+          onViewActiveJob={(jobId, kind) => {
+            setResumeJob({ jobId, kind });
+            setView("processing");
+          }}
           sendingBundle={sendingBundle}
           sendBundleError={sendBundleError}
           onRenameProject={(newName) =>
@@ -458,7 +470,10 @@ export default function AppRouter({
     case "processing":
       return selectedProject ? (
         <ProcessingPage
-          onBack={() => setView("project")}
+          onBack={() => {
+            setResumeJob(null);
+            setView("project");
+          }}
           onComplete={() => {
             if (selectedProjectId && selectedProject) {
               updateProjectSteps(
@@ -466,131 +481,140 @@ export default function AppRouter({
                 Math.max(selectedProject.stepsUnlocked, 1),
               );
             }
+            setResumeJob(null);
             setView("completion");
           }}
           projectId={selectedProject.id}
-          jobKind={batchRunIds ? "text_batch" : "predict"}
-          streamRequest={(signal, onJobId) => {
-            const usedModelId =
-              selectedProject.models.find((m) =>
-                (selectedProject.usedModelNames ?? []).includes(m.name),
-              )?.id ?? "";
-            const resolvedCustomModelId =
-              inferenceSettings.customModelId || usedModelId;
-            if (batchRunIds) {
-              return apiFetchJobStream(
-                `/api/projects/${selectedProject.id}/text-batch/run`,
-                {
-                  method: "POST",
-                  headers: { "Content-Type": "application/json" },
-                  body: JSON.stringify({
-                    image_ids: batchRunIds.imageIds,
-                    folios: batchRunIds.folios,
-                    source_id: Number(textFindingSettings.sourceId),
-                    segmentation_model:
-                      textFindingSettings.segmentationModelId || null,
-                    recognition_model:
-                      textFindingSettings.recognitionModelId || null,
-                    device: textFindingSettings.device,
-                    column_count:
-                      textFindingSettings.columnCount === "auto"
-                        ? null
-                        : Number(textFindingSettings.columnCount),
-                    column_bimodal_threshold:
-                      textFindingSettings.columnBimodalThreshold,
-                    masking_enabled: textFindingSettings.maskingEnabled,
-                    mask_padding: textFindingSettings.maskPadding,
-                    music_overlap_filter_enabled:
-                      textFindingSettings.musicOverlapFilterEnabled,
-                    debug_mode: textFindingSettings.debugMode,
-                    mask_model_id: textFindingSettings.maskModelId || null,
-                    model_preset: inferenceSettings.modelPreset,
-                    model_id:
-                      inferenceSettings.modelPreset === "custom"
-                        ? resolvedCustomModelId
-                        : null,
-                    yolo_confidence_threshold: inferenceSettings.threshold,
-                    yolo_device: inferenceSettings.device,
-                    text_music_confidence_threshold:
-                      inferenceSettings.useSharedDetectorSettings
-                        ? null
-                        : inferenceSettings.textMusicSettings.threshold,
-                    text_music_device:
-                      inferenceSettings.useSharedDetectorSettings
+          jobKind={resumeJob?.kind ?? (batchRunIds ? "text_batch" : "predict")}
+          streamRequest={
+            resumeJob
+              ? (signal, onJobId) => {
+                  onJobId?.(resumeJob.jobId);
+                  return apiFetch(`/api/jobs/${resumeJob.jobId}/stream`, {
+                    signal,
+                  });
+              }
+            : (signal, onJobId) => {
+                const usedModelId =
+                  selectedProject.models.find((m) =>
+                    (selectedProject.usedModelNames ?? []).includes(m.name),
+                  )?.id ?? "";
+                const resolvedCustomModelId =
+                  inferenceSettings.customModelId || usedModelId;
+                if (batchRunIds) {
+                  return apiFetchJobStream(
+                    `/api/projects/${selectedProject.id}/text-batch/run`,
+                    {
+                      method: "POST",
+                      headers: { "Content-Type": "application/json" },
+                      body: JSON.stringify({
+                        image_ids: batchRunIds.imageIds,
+                        folios: batchRunIds.folios,
+                        source_id: Number(textFindingSettings.sourceId),
+                        segmentation_model:
+                          textFindingSettings.segmentationModelId || null,
+                        recognition_model:
+                          textFindingSettings.recognitionModelId || null,
+                        device: textFindingSettings.device,
+                        column_count:
+                          textFindingSettings.columnCount === "auto"
+                            ? null
+                            : Number(textFindingSettings.columnCount),
+                        column_bimodal_threshold:
+                          textFindingSettings.columnBimodalThreshold,
+                        masking_enabled: textFindingSettings.maskingEnabled,
+                        mask_padding: textFindingSettings.maskPadding,
+                        music_overlap_filter_enabled:
+                          textFindingSettings.musicOverlapFilterEnabled,
+                        debug_mode: textFindingSettings.debugMode,
+                        mask_model_id: textFindingSettings.maskModelId || null,
+                        model_preset: inferenceSettings.modelPreset,
+                        model_id:
+                          inferenceSettings.modelPreset === "custom"
+                            ? resolvedCustomModelId
+                            : null,
+                        yolo_confidence_threshold: inferenceSettings.threshold,
+                        yolo_device: inferenceSettings.device,
+                        text_music_confidence_threshold:
+                          inferenceSettings.useSharedDetectorSettings
+                            ? null
+                            : inferenceSettings.textMusicSettings.threshold,
+                        text_music_device:
+                          inferenceSettings.useSharedDetectorSettings
+                            ? null
+                            : inferenceSettings.textMusicSettings.device,
+                        stave_confidence_threshold:
+                          inferenceSettings.useSharedDetectorSettings
+                            ? null
+                            : inferenceSettings.staveSettings.threshold,
+                        stave_device: inferenceSettings.useSharedDetectorSettings
+                          ? null
+                          : inferenceSettings.staveSettings.device,
+                      }),
+                    },
+                    signal,
+                    onJobId,
+                  );
+                }
+                const usedImageIds = selectedProject.images
+                  .filter((i) => selectedProject.usedImageNames.includes(i.name))
+                  .map((i) => i.id);
+                return apiFetchJobStream(
+                  `/api/projects/${selectedProject.id}/predict`,
+                  {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                      model_preset: inferenceSettings.modelPreset,
+                      model_id:
+                        inferenceSettings.modelPreset === "custom"
+                          ? resolvedCustomModelId
+                          : null,
+                      image_ids: usedImageIds,
+                      confidence_threshold: inferenceSettings.threshold,
+                      device: inferenceSettings.device,
+                      text_music_confidence_threshold:
+                        inferenceSettings.useSharedDetectorSettings
+                          ? null
+                          : inferenceSettings.textMusicSettings.threshold,
+                      text_music_device: inferenceSettings.useSharedDetectorSettings
                         ? null
                         : inferenceSettings.textMusicSettings.device,
-                    stave_confidence_threshold:
-                      inferenceSettings.useSharedDetectorSettings
+                      stave_confidence_threshold:
+                        inferenceSettings.useSharedDetectorSettings
+                          ? null
+                          : inferenceSettings.staveSettings.threshold,
+                      stave_device: inferenceSettings.useSharedDetectorSettings
                         ? null
-                        : inferenceSettings.staveSettings.threshold,
-                    stave_device: inferenceSettings.useSharedDetectorSettings
-                      ? null
-                      : inferenceSettings.staveSettings.device,
-                  }),
-                },
-                signal,
-                onJobId,
-              );
-            }
-            const usedImageIds = selectedProject.images
-              .filter((i) => selectedProject.usedImageNames.includes(i.name))
-              .map((i) => i.id);
-            return apiFetchJobStream(
-              `/api/projects/${selectedProject.id}/predict`,
-              {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                  model_preset: inferenceSettings.modelPreset,
-                  model_id:
-                    inferenceSettings.modelPreset === "custom"
-                      ? resolvedCustomModelId
-                      : null,
-                  image_ids: usedImageIds,
-                  confidence_threshold: inferenceSettings.threshold,
-                  device: inferenceSettings.device,
-                  text_music_confidence_threshold:
-                    inferenceSettings.useSharedDetectorSettings
-                      ? null
-                      : inferenceSettings.textMusicSettings.threshold,
-                  text_music_device: inferenceSettings.useSharedDetectorSettings
-                    ? null
-                    : inferenceSettings.textMusicSettings.device,
-                  stave_confidence_threshold:
-                    inferenceSettings.useSharedDetectorSettings
-                      ? null
-                      : inferenceSettings.staveSettings.threshold,
-                  stave_device: inferenceSettings.useSharedDetectorSettings
-                    ? null
-                    : inferenceSettings.staveSettings.device,
-                  text_column_count:
-                    textFindingSettings.columnCount === "auto"
-                      ? null
-                      : Number(textFindingSettings.columnCount),
-                  text_segmentation_model_id:
-                    textFindingSettings.segmentationModelId || null,
-                  text_recognition_model_id:
-                    textFindingSettings.recognitionModelId || null,
-                  text_device: textFindingSettings.device,
-                  text_column_bimodal_threshold:
-                    textFindingSettings.columnBimodalThreshold,
-                  text_masking_enabled: textFindingSettings.maskingEnabled,
-                  text_mask_padding: textFindingSettings.maskPadding,
-                  text_music_overlap_filter_enabled:
-                    textFindingSettings.musicOverlapFilterEnabled,
-                  text_debug_mode: textFindingSettings.debugMode,
-                  text_mask_model_id: textFindingSettings.maskModelId || null,
-                  text_source_id:
-                    !textFindingSettings.ocrOnlyMode &&
-                    textFindingSettings.sourceId
-                      ? Number(textFindingSettings.sourceId)
-                      : null,
-                }),
-              },
-              signal,
-              onJobId,
-            );
-          }}
+                        : inferenceSettings.staveSettings.device,
+                      text_column_count:
+                        textFindingSettings.columnCount === "auto"
+                          ? null
+                          : Number(textFindingSettings.columnCount),
+                      text_segmentation_model_id:
+                        textFindingSettings.segmentationModelId || null,
+                      text_recognition_model_id:
+                        textFindingSettings.recognitionModelId || null,
+                      text_device: textFindingSettings.device,
+                      text_column_bimodal_threshold:
+                        textFindingSettings.columnBimodalThreshold,
+                      text_masking_enabled: textFindingSettings.maskingEnabled,
+                      text_mask_padding: textFindingSettings.maskPadding,
+                      text_music_overlap_filter_enabled:
+                        textFindingSettings.musicOverlapFilterEnabled,
+                      text_debug_mode: textFindingSettings.debugMode,
+                      text_mask_model_id: textFindingSettings.maskModelId || null,
+                      text_source_id:
+                        !textFindingSettings.ocrOnlyMode &&
+                        textFindingSettings.sourceId
+                          ? Number(textFindingSettings.sourceId)
+                          : null,
+                    }),
+                  },
+                  signal,
+                  onJobId,
+                );
+              }}
           onResult={(ev) => {
             if (batchRunIds) {
               const { text_debug_data: batchDebugData } = ev as {

--- a/landing-page/src/components/AppRouter.tsx
+++ b/landing-page/src/components/AppRouter.tsx
@@ -473,6 +473,14 @@ export default function AppRouter({
     case "processing":
       return selectedProject ? (
         <ProcessingPage
+          // Force a remount when a NEW resumed job is set while this exact
+          // case is already rendering (onViewActiveJob/App.tsx's toast
+          // handler can both fire while view is already "processing") --
+          // without this, ProcessingPage's kickoff effect (keyed on
+          // retryKey, not streamRequest) keeps streaming whatever job it
+          // mounted with, so "view progress"/toast "view" on a second job
+          // would silently keep showing the first one's logs.
+          key={resumeJob?.jobId ?? "new"}
           onBack={() => {
             setResumeJob(null);
             setView("project");
@@ -620,7 +628,18 @@ export default function AppRouter({
                 );
               }}
           onResult={(ev) => {
-            if (batchRunIds) {
+            // Effective kind for THIS mount: a resumed job's own kind wins
+            // over whatever this tab last kicked off. batchRunIds reflects
+            // this tab's last kickoff, not the job actually being watched --
+            // resuming a text_batch job in a fresh tab (batchRunIds null)
+            // would otherwise take the predict branch and read `ev.annotations`
+            // off a batch result that doesn't carry it, and resuming a
+            // predict job after this tab last ran a batch (batchRunIds still
+            // set) would take the batch branch and write a bogus batchResult.
+            const isBatchResult = resumeJob
+              ? resumeJob.kind === "text_batch"
+              : !!batchRunIds;
+            if (isBatchResult) {
               const { text_debug_data: batchDebugData } = ev as {
                 text_debug_data?: Record<string, unknown>;
               };

--- a/landing-page/src/components/project/ProjectDetail.tsx
+++ b/landing-page/src/components/project/ProjectDetail.tsx
@@ -188,19 +188,37 @@ export default function ProjectDetail({
     : serverActiveJob;
   const [cancellingJob, setCancellingJob] = useState(false);
   const [cancelJobPrompt, setCancelJobPrompt] = useState(false);
+  const [cancelJobError, setCancelJobError] = useState<string | null>(null);
 
   const handleCancelActiveJob = async () => {
     if (!activeJobForProject) return;
     setCancellingJob(true);
+    setCancelJobError(null);
     try {
-      await apiFetch(`/api/jobs/${activeJobForProject.jobId}/cancel`, {
-        method: "POST",
-      });
+      const r = await apiFetch(
+        `/api/jobs/${activeJobForProject.jobId}/cancel`,
+        { method: "POST" },
+      );
+      if (!r.ok) {
+        // A 404/403/409 means the job is NOT actually cancelled server-side
+        // -- settling it locally anyway would silently hide a still-running
+        // job with no error shown and no way left to cancel it for real.
+        const d = await r.json().catch(() => ({}));
+        setCancelJobError(
+          (d as { detail?: string }).detail ?? `cancel failed (${r.status})`,
+        );
+        setCancellingJob(false);
+        return;
+      }
       markJobSettled(activeJobForProject.jobId);
       await refetchActiveJob();
-    } finally {
       setCancellingJob(false);
       setCancelJobPrompt(false);
+    } catch {
+      // apiFetch rejects on a network failure -- surface it instead of
+      // letting it escape the click handler as an unhandled rejection.
+      setCancelJobError("cancel failed -- check your connection");
+      setCancellingJob(false);
     }
   };
   
@@ -991,7 +1009,12 @@ export default function ProjectDetail({
                   {activeJobForProject && (
                     <div className="mt-2 flex flex-col items-center gap-1.5">
                       <p className="text-white/70 text-xs text-center">
-                        an {jobKindLabel(activeJobForProject.kind)} job is{" "}
+                        {/^[aeiou]/i.test(
+                          jobKindLabel(activeJobForProject.kind),
+                        )
+                          ? "an"
+                          : "a"}{" "}
+                        {jobKindLabel(activeJobForProject.kind)} job is{" "}
                         {activeJobForProject.status === "pending"
                           ? "queued"
                           : "running"}{" "}
@@ -1038,6 +1061,11 @@ export default function ProjectDetail({
                           </span>
                         )}
                       </div>
+                      {cancelJobError && (
+                        <p className="text-red-200 text-xs text-center">
+                          {cancelJobError}
+                        </p>
+                      )}
                     </div>
                   )}
                 </>

--- a/landing-page/src/components/project/ProjectDetail.tsx
+++ b/landing-page/src/components/project/ProjectDetail.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
-import type { Project, ModelKind, CantusSource } from "../../types";
+import type { Project, ModelKind, CantusSource, ProjectInitialTab } from "../../types";
 import { apiFetch } from "../../lib/apiFetch";
 import { getImageProgress, minNextStep } from "../../utils/imageStep";
 import { useAssetSection } from "../../hooks/useAssetSection";
@@ -62,6 +62,11 @@ interface ProjectDetailProps {
   onResumeIcSession: (req: IcResumeRequest) => void;
   onSendToCantus: () => void;
   onViewActiveJob: (jobId: string, kind: string) => void;
+  /** Deep-links the tab/sub-tab this mount should open on -- set by App.tsx's
+   * job-done toast handler for a succeeded job (issue #196). Null for every
+   * ordinary navigation into this page. */
+  initialTab?: ProjectInitialTab | null;
+  onInitialTabConsumed?: () => void;
   sendingBundle?: boolean;
   sendBundleError?: string | null;
   onRenameProject: (newName: string) => void;
@@ -108,6 +113,8 @@ export default function ProjectDetail({
   onResumeIcSession,
   onSendToCantus,
   onViewActiveJob,
+  initialTab,
+  onInitialTabConsumed,
   sendingBundle = false,
   sendBundleError = null,
   onRenameProject,
@@ -124,11 +131,26 @@ export default function ProjectDetail({
   textFindingSettings,
 }: ProjectDetailProps) {
   const [activeTab, setActiveTab] = useState<"images" | "models" | "generated">(
-    "images",
+    initialTab?.tab ?? "images",
   );
   const [generatedSubTab, setGeneratedSubTab] = useState<
     "annotations" | "text" | "stafflines" | "mei files"
-  >("annotations");
+  >(initialTab?.subTab ?? "annotations");
+
+  // Reacts to initialTab CHANGING, not just seeding on mount -- a toast's
+  // "view" click often lands here while ProjectDetail is already mounted
+  // (the user was sitting on the project page when the job finished), which
+  // re-renders this same case in AppRouter's switch rather than
+  // unmounting/remounting it. A mount-only effect would silently no-op in
+  // that case, which is exactly what "view" looked like it was doing
+  // nothing.
+  useEffect(() => {
+    if (!initialTab) return;
+    setActiveTab(initialTab.tab);
+    if (initialTab.subTab) setGeneratedSubTab(initialTab.subTab);
+    onInitialTabConsumed?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialTab]);
   const [validationError, setValidationError] = useState<string | null>(null);
 
   // Client-side mirror of the backend's cross-kind "one active job per
@@ -969,7 +991,7 @@ export default function ProjectDetail({
                   {activeJobForProject && (
                     <div className="mt-2 flex flex-col items-center gap-1.5">
                       <p className="text-white/70 text-xs text-center">
-                        a {jobKindLabel(activeJobForProject.kind)} job is{" "}
+                        an {jobKindLabel(activeJobForProject.kind)} job is{" "}
                         {activeJobForProject.status === "pending"
                           ? "queued"
                           : "running"}{" "}

--- a/landing-page/src/components/project/ProjectDetail.tsx
+++ b/landing-page/src/components/project/ProjectDetail.tsx
@@ -22,7 +22,9 @@ import TruncatedName from "../shared/TruncatedName";
 import {
   subscribeActiveJobs,
   getActiveJobsSnapshot,
+  markJobSettled,
 } from "../../lib/activeJobs";
+import { useProjectActiveJob } from "../../hooks/useProjectActiveJob";
 
 const STEPS = [
   "annotate",
@@ -31,6 +33,16 @@ const STEPS = [
   "neon",
   "send to cantus ultimus",
 ];
+
+const JOB_KIND_LABELS: Record<string, string> = {
+  predict: "annotation",
+  text_batch: "text-finding",
+  encode_upload: "encoding",
+  encode_batch: "batch encoding",
+};
+function jobKindLabel(kind: string): string {
+  return JOB_KIND_LABELS[kind] ?? kind;
+}
 
 interface ProjectDetailProps {
   project: Project;
@@ -49,6 +61,7 @@ interface ProjectDetailProps {
    * IC step page (step 1), rather than inside the modal's iframe. */
   onResumeIcSession: (req: IcResumeRequest) => void;
   onSendToCantus: () => void;
+  onViewActiveJob: (jobId: string, kind: string) => void;
   sendingBundle?: boolean;
   sendBundleError?: string | null;
   onRenameProject: (newName: string) => void;
@@ -94,6 +107,7 @@ export default function ProjectDetail({
   onStepClick,
   onResumeIcSession,
   onSendToCantus,
+  onViewActiveJob,
   sendingBundle = false,
   sendBundleError = null,
   onRenameProject,
@@ -116,18 +130,58 @@ export default function ProjectDetail({
     "annotations" | "text" | "stafflines" | "mei files"
   >("annotations");
   const [validationError, setValidationError] = useState<string | null>(null);
+
   // Client-side mirror of the backend's cross-kind "one active job per
   // project" guard (job_store.py's get_active_job_for_project) — disables
   // Continue before the user can even attempt a kickoff that the backend
-  // would reject with a 409, instead of them hitting an error. The backend
-  // check remains the actual source of truth (this registry is in-memory,
-  // reset on reload, not shared across tabs).
+  // would reject with a 409, instead of them hitting an error.
+  //
+  // Two sources, combined: the in-memory registry (activeJobs.ts) knows
+  // immediately when THIS tab kicked a job off; useProjectActiveJob polls
+  // the server so a reload or a different tab's kickoff is discovered too.
+  // The backend's own 409 check remains the actual source of truth either
+  // way — both of these are just UI conveniences to avoid surprising the
+  // user with an error, or leaving them with no way to check on/cancel a
+  // job they can't see.
   const activeJobsSnapshot = useSyncExternalStore(
     subscribeActiveJobs,
     getActiveJobsSnapshot,
   );
-  const activeJobForProject =
+  const inMemoryActiveJob = 
     activeJobsSnapshot.find((j) => j.projectId === project.id) ?? null;
+  const { activeJob: serverActiveJob, refetchActiveJob } = useProjectActiveJob(project.id);
+  const activeJobForProject: {
+    jobId: string;
+    kind: string;
+    status: string | null;
+  } | null = inMemoryActiveJob
+    ? {
+      jobId: inMemoryActiveJob.jobId,
+        kind: inMemoryActiveJob.kind,
+        status:
+          serverActiveJob?.jobId === inMemoryActiveJob.jobId
+            ? serverActiveJob.status
+            : null,
+      }
+    : serverActiveJob;
+  const [cancellingJob, setCancellingJob] = useState(false);
+  const [cancelJobPrompt, setCancelJobPrompt] = useState(false);
+
+  const handleCancelActiveJob = async () => {
+    if (!activeJobForProject) return;
+    setCancellingJob(true);
+    try {
+      await apiFetch(`/api/jobs/${activeJobForProject.jobId}/cancel`, {
+        method: "POST",
+      });
+      markJobSettled(activeJobForProject.jobId);
+      await refetchActiveJob();
+    } finally {
+      setCancellingJob(false);
+      setCancelJobPrompt(false);
+    }
+  };
+  
   const [projectMenu, setProjectMenu] = useState(false);
   const [projectRenameModal, setProjectRenameModal] = useState(false);
   const [projectRenameName, setProjectRenameName] = useState("");
@@ -913,10 +967,56 @@ export default function ProjectDetail({
                     {continueLabel} &rarr;
                   </button>
                   {activeJobForProject && (
-                    <p className="text-white/70 text-xs mt-1 text-center">
-                      a {activeJobForProject.kind} job is already running for
-                      this project — please wait for it to finish
-                    </p>
+                    <div className="mt-2 flex flex-col items-center gap-1.5">
+                      <p className="text-white/70 text-xs text-center">
+                        a {jobKindLabel(activeJobForProject.kind)} job is{" "}
+                        {activeJobForProject.status === "pending"
+                          ? "queued"
+                          : "running"}{" "}
+                        for this project
+                      </p>
+                      <div className="flex items-center gap-3 text-xs">
+                        {(activeJobForProject.kind === "predict" ||
+                          activeJobForProject.kind === "text_batch") && (
+                          <button
+                            onClick={() =>
+                              onViewActiveJob(
+                                activeJobForProject.jobId,
+                                activeJobForProject.kind,
+                              )
+                            }
+                            className="text-white underline hover:opacity-80 cursor-pointer"
+                          >
+                            view progress
+                          </button>
+                        )}
+                        {!cancelJobPrompt ? (
+                          <button
+                            onClick={() => setCancelJobPrompt(true)}
+                            className="text-white/70 underline hover:text-white cursor-pointer"
+                          >
+                            cancel job
+                          </button>
+                        ) : (
+                          <span className="flex items-center gap-2 text-white">
+                            cancel it?
+                            <button
+                              onClick={handleCancelActiveJob}
+                              disabled={cancellingJob}
+                              className="px-2 py-0.5 bg-white text-[#4AADAA] rounded font-semibold disabled:opacity-50 cursor-pointer"
+                            >
+                              {cancellingJob ? "cancelling..." : "yes"}
+                            </button>
+                            <button
+                              onClick={() => setCancelJobPrompt(false)}
+                              className="px-2 py-0.5 border border-white/40 rounded cursor-pointer"
+                            >
+                              no
+                            </button>
+                          </span>
+                        )}
+                      </div>
+                    </div>
                   )}
                 </>
               );

--- a/landing-page/src/components/workflow/ProcessingPage.tsx
+++ b/landing-page/src/components/workflow/ProcessingPage.tsx
@@ -25,6 +25,7 @@ interface ProcessingPageProps {
   onBatchDone?: (summary: { succeeded: unknown[]; failed: unknown[] }) => void;
   projectId?: number | null;
   jobKind?: string;
+  initialLogsOpen?: boolean;
 }
 
 const STAGE_LABELS = ["checking", "validating", "processing"];
@@ -66,6 +67,7 @@ export default function ProcessingPage({
   onBatchDone,
   projectId,
   jobKind,
+  initialLogsOpen = false,
 }: ProcessingPageProps) {
   const [done, setDone] = useState(false);
   const [progress, setProgress] = useState(0);
@@ -74,7 +76,7 @@ export default function ProcessingPage({
     { text: false, check: false },
     { text: false, check: false },
   ]);
-  const [logsOpen, setLogsOpen] = useState(false);
+  const [logsOpen, setLogsOpen] = useState(initialLogsOpen);
   const [cancelPrompt, setCancelPrompt] = useState(false);
   const pausedRef = useRef(false);
   const completedRef = useRef(false);
@@ -595,7 +597,11 @@ export default function ProcessingPage({
                   {revealedLogs.map((line, i) => (
                     <div
                       key={i}
-                      className="text-white/70 text-xs font-mono leading-5"
+                      className={`text-xs font-mono leading-5 ${
+                        line.startsWith("error: ")
+                          ? "text-red-300"
+                          : "text-white/70"
+                      }`}
                     >
                       {line}
                     </div>

--- a/landing-page/src/hooks/useProjectActiveJob.ts
+++ b/landing-page/src/hooks/useProjectActiveJob.ts
@@ -23,8 +23,20 @@ export function useProjectActiveJob(projectId: number | null) {
         try {
             const r = await apiFetch(`/api/projects/${projectId}/active-job`);
             if (!r.ok) return;
-            const data: ProjectActiveJob | null = await r.json();
-            setJob(data);
+            // The backend (projects_api.py's get_project_active_job) returns
+            // snake_case ({job_id, kind, status}), matching every other API
+            // response in this codebase -- map it explicitly rather than
+            // casting, or every consumer of the server-only path (a job
+            // discovered after a reload/from a different tab, with nothing
+            // in the in-memory activeJobs.ts registry to fall back on) reads
+            // `jobId` as undefined.
+            const data: { job_id: string; kind: string; status: string } | null =
+                await r.json();
+            setJob(
+                data
+                    ? { jobId: data.job_id, kind: data.kind, status: data.status }
+                    : null,
+            );
         } catch {
             // network hiccup -- keep the last known value rather than flashing to null
         }
@@ -40,10 +52,13 @@ export function useProjectActiveJob(projectId: number | null) {
     // terminal-status poll, but ONLY while a job is actually known to be
     // active -- polling unconditionally for as long as ProjectDetail stays
     // mounted (even with nothing ever having run) spammed the backend with
-    // GET .../active-job requests forever for no reason. The tradeoff: a
-    // job started in a DIFFERENT tab while this one sits idle here with no
-    // job of its own won't be noticed until this component remounts -- an
-    // edge case, versus indefinite chatty polling being the common case.
+    // GET .../active-job requests forever for no reason. Known gap: a job
+    // started elsewhere while THIS hook's `job` is null won't be noticed
+    // until it remounts -- whether "elsewhere" is a different tab, or this
+    // same tab kicking one off without a remount in between. The in-memory
+    // activeJobs.ts registry covers the same-tab case for the "is Continue
+    // disabled" check itself; what's missed here is just this hook's own
+    // `status` label staying stale until the next mount/poll tick.
     useEffect(() => {
         if (!job) return;
         const interval = setInterval(refetch, 5000);

--- a/landing-page/src/hooks/useProjectActiveJob.ts
+++ b/landing-page/src/hooks/useProjectActiveJob.ts
@@ -30,14 +30,25 @@ export function useProjectActiveJob(projectId: number | null) {
         }
     }, [projectId]);
 
+    // One refetch on mount (or when projectId changes) -- this alone is what
+    // catches a post-reload or a different tab's already-in-progress job.
     useEffect(() => {
         refetch();
-        // Same 5s cadence as useActiveJobWatcher's terminal-status poll -- cheap,
-        // and this is the only way a different tab's kickoff or a post-reload
-        // in-progress job is ever discovered on this page.
+    }, [refetch]);
+
+    // Keep polling on the same 5s cadence as useActiveJobWatcher's
+    // terminal-status poll, but ONLY while a job is actually known to be
+    // active -- polling unconditionally for as long as ProjectDetail stays
+    // mounted (even with nothing ever having run) spammed the backend with
+    // GET .../active-job requests forever for no reason. The tradeoff: a
+    // job started in a DIFFERENT tab while this one sits idle here with no
+    // job of its own won't be noticed until this component remounts -- an
+    // edge case, versus indefinite chatty polling being the common case.
+    useEffect(() => {
+        if (!job) return;
         const interval = setInterval(refetch, 5000);
         return () => clearInterval(interval);
-    }, [refetch]);
+    }, [job, refetch]);
 
     return { activeJob: job, refetchActiveJob: refetch };
 }

--- a/landing-page/src/hooks/useProjectActiveJob.ts
+++ b/landing-page/src/hooks/useProjectActiveJob.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useState } from "react";
+import { apiFetch } from "../lib/apiFetch";
+
+export interface ProjectActiveJob {
+    jobId: string;
+    kind: string;
+    status: string;
+}
+
+/** Polls GET /api/projects/{id}/active-job -- the server-side source of
+ * truth for job_store.py's get_active_job_for_project -- so the project page
+ * can show progress/cancel controls even after a reload or from a different
+ * tab than the one that kicked the job off. activeJobs.ts's in-memory
+ * registry only covers the same-tab-session case; this covers the rest. */
+export function useProjectActiveJob(projectId: number | null) {
+    const [job, setJob] = useState<ProjectActiveJob | null>(null);
+
+    const refetch = useCallback(async () => {
+        if (projectId == null) {
+            setJob(null);
+            return;
+        }
+        try {
+            const r = await apiFetch(`/api/projects/${projectId}/active-job`);
+            if (!r.ok) return;
+            const data: ProjectActiveJob | null = await r.json();
+            setJob(data);
+        } catch {
+            // network hiccup -- keep the last known value rather than flashing to null
+        }
+    }, [projectId]);
+
+    useEffect(() => {
+        refetch();
+        // Same 5s cadence as useActiveJobWatcher's terminal-status poll -- cheap,
+        // and this is the only way a different tab's kickoff or a post-reload
+        // in-progress job is ever discovered on this page.
+        const interval = setInterval(refetch, 5000);
+        return () => clearInterval(interval);
+    }, [refetch]);
+
+    return { activeJob: job, refetchActiveJob: refetch };
+}

--- a/landing-page/src/lib/activeJobs.ts
+++ b/landing-page/src/lib/activeJobs.ts
@@ -16,6 +16,12 @@ export function registerActiveJobs(
   projectId: number | null,
   kind: string,
 ) {
+  // Idempotent by jobId -- a "view progress" reconnect (AppRouter's
+  // resumeJob path, see ProjectDetail.tsx) re-registers a job that may
+  // already be here from its original kickoff; without this guard the same
+  // jobId would accumulate duplicate entries every time its ProcessingPage
+  // is reopened.
+  if (activeJobs.some((j) => j.jobId === jobId)) return;
   activeJobs = [...activeJobs, { jobId, projectId, kind }];
   emitChange();
 }

--- a/landing-page/src/types.ts
+++ b/landing-page/src/types.ts
@@ -28,6 +28,16 @@ export interface Project {
   stafflines: StafflineSet[];
 }
 
+/** Which tab/sub-tab ProjectDetail should open on mount -- set by App.tsx's
+ * job-done toast handler when routing "view" for a succeeded job to the tab
+ * that actually holds what it produced (issue #196). Consumed once via
+ * ProjectDetail's onInitialTabConsumed and then cleared, so an unrelated
+ * later navigation back to the project page doesn't re-apply a stale value. */
+export interface ProjectInitialTab {
+  tab: "images" | "models" | "generated";
+  subTab?: "annotations" | "text" | "stafflines" | "mei files";
+}
+
 export interface CantusSource {
   sourceId: string;
   name: string;


### PR DESCRIPTION
refs: #195, #196

- leaving the processing page during a run and going to the project detail page resulted in the "begin" button being greyed out with text that a processing run was in progress, but with no way to view the progress or cancel the job
- pressing view on the job succeeded/error toasts brought the user back to the projectdetail page, which wasn't very informative in the latter case; hopefully added a fix that will open the respective/corresponding tabs or logs depending on the toast content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added active-job status tracking and polling for projects.
  - Added project active-job details, including job type and status.
  - Enabled resuming active, failed, or cancelled jobs from project views.
  - Added navigation to relevant result tabs after successful processing.
  - Added deep links to project tabs and sub-tabs.
  - Added job cancellation, progress navigation, and reconnectable processing logs.
- **Bug Fixes**
  - Prevented duplicate active-job entries.
  - Highlighted processing errors in the log panel for easier identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->