### PR TITLE
fix: estimated time, project name, & cancelling job bugs

### DIFF
--- a/landing-page/scripts/job_store.py
+++ b/landing-page/scripts/job_store.py
@@ -123,9 +123,11 @@ def claim_project_job(project_id: int, kind: str, *, job_id: str,
         release_db_conn(con)
 
 def get_active_job_for_project(project_id: int) -> Optional[dict]:
-    """Returns {"job_id": ..., "kind": ..., "status": ...} for the most recent
-    pending/running job for this project, across ALL kinds, or None if there
-    isn't one.
+    """Returns {"job_id": ..., "kind": ..., "status": ..., "created_at": ...}
+    for the most recent pending/running job for this project, across ALL
+    kinds, or None if there isn't one. `created_at` is the raw datetime from
+    the `jobs` row (callers over HTTP, e.g. projects_api.py's
+    get_project_active_job, are responsible for serializing it).
 
     Unlike create_job's dedupe_seconds (scoped to kind+project_id, and only a
     few-second window — meant to collapse an exact duplicate kickoff, e.g. a

--- a/landing-page/scripts/job_store.py
+++ b/landing-page/scripts/job_store.py
@@ -144,14 +144,18 @@ def get_active_job_for_project(project_id: int) -> Optional[dict]:
     try:
         cur = con.cursor()
         cur.execute(
-            "SELECT job_id, kind, status FROM jobs WHERE project_id=%s"
+            "SELECT job_id, kind, status, created_at FROM jobs WHERE project_id=%s"
             " AND status IN ('pending','running')"
             " ORDER BY created_at DESC LIMIT 1",
             (project_id,),
         )
         row = cur.fetchone()
         cur.close()
-        return {"job_id": row[0], "kind": row[1], "status": row[2]} if row else None
+        return (
+            {"job_id": row[0], "kind": row[1], "status": row[2], "created_at": row[3]}
+            if row
+            else None
+        )
     finally:
         release_db_conn(con)
 

--- a/landing-page/scripts/projects_api.py
+++ b/landing-page/scripts/projects_api.py
@@ -240,7 +240,12 @@ def get_project_active_job(project_id: int, user=Depends(get_current_user)):
     active = get_active_job_for_project(project_id)
     if active is None:
         return None
-    return {"job_id": active["job_id"], "kind": active["kind"], "status": active["status"]}
+    return {
+        "job_id": active["job_id"],
+        "kind": active["kind"],
+        "status": active["status"],
+        "created_at": active["created_at"].isoformat() if active["created_at"] else None,
+    }
 
 class CreateProjectBody(BaseModel):
     name: str

--- a/landing-page/src/App.tsx
+++ b/landing-page/src/App.tsx
@@ -56,6 +56,7 @@ export default function App() {
   const [resumeJob, setResumeJob] = useState<{
     jobId: string;
     kind: string;
+    startedAt?: string | null;
   } | null>(null);
   const [pendingProjectTab, setPendingProjectTab] =
     useState<ProjectInitialTab | null>(null);

--- a/landing-page/src/components/AppRouter.tsx
+++ b/landing-page/src/components/AppRouter.tsx
@@ -105,8 +105,10 @@ interface AppRouterProps {
   }) => void;
   pendingBatchPairs: { xmlFile: File; imageFile: File }[];
   setPendingBatchPairs: (pairs: { xmlFile: File; imageFile: File }[]) => void;
-  resumeJob: { jobId: string; kind: string } | null;
-  setResumeJob: (job: { jobId: string; kind: string } | null) => void;
+  resumeJob: { jobId: string; kind: string; startedAt?: string | null} | null;
+  setResumeJob: (
+    job: { jobId: string; kind: string; startedAt?: string | null } | null,
+  ) => void;
   pendingProjectTab: ProjectInitialTab | null;
   setPendingProjectTab: (tab: ProjectInitialTab | null) => void;
   handleEncodeBatchResult: (ev: {
@@ -381,8 +383,8 @@ export default function AppRouter({
             setView("ic");
           }}
           onSendToCantus={handleSendToCantus}
-          onViewActiveJob={(jobId, kind) => {
-            setResumeJob({ jobId, kind });
+          onViewActiveJob={(jobId, kind, startedAt) => {
+            setResumeJob({ jobId, kind, startedAt });
             setView("processing");
           }}
           initialTab={pendingProjectTab}
@@ -524,6 +526,9 @@ export default function AppRouter({
           projectId={selectedProject.id}
           jobKind={resumeJob?.kind ?? (batchRunIds ? "text_batch" : "predict")}
           initialLogsOpen={!!resumeJob}
+          startedAtMs={
+            resumeJob?.startedAt ? new Date(resumeJob.startedAt).getTime() : undefined
+          }
           streamRequest={
             resumeJob
               ? (signal, onJobId) => {

--- a/landing-page/src/components/project/ProjectDetail.tsx
+++ b/landing-page/src/components/project/ProjectDetail.tsx
@@ -557,12 +557,12 @@ export default function ProjectDetail({
           <div className="flex items-center gap-4 mb-3">
             <button
               onClick={onBack}
-              className="text-white text-2xl hover:opacity-70 transition-opacity cursor-pointer shrink-0"
+              className="text-white text-2xl hover:opacity-70 transition-opacity cursor-pointer shrink-0 mt-1"
             >
               ←
             </button>
-            <h1 className="text-4xl font-bold italic text-white min-w-0 shrink">
-              <TruncatedName name={project.name} />
+            <h1 className="text-4xl font-bold italic text-white min-w-0 shrink break-words">
+              {project.name}
             </h1>
             <div className="relative shrink-0">
               <button

--- a/landing-page/src/components/project/ProjectDetail.tsx
+++ b/landing-page/src/components/project/ProjectDetail.tsx
@@ -62,7 +62,7 @@ interface ProjectDetailProps {
    * IC step page (step 1), rather than inside the modal's iframe. */
   onResumeIcSession: (req: IcResumeRequest) => void;
   onSendToCantus: () => void;
-  onViewActiveJob: (jobId: string, kind: string) => void;
+  onViewActiveJob: (jobId: string, kind: string, startedAt?: string | null) => void;
   /** Deep-links the tab/sub-tab this mount should open on -- set by App.tsx's
    * job-done toast handler for a succeeded job (issue #196). Null for every
    * ordinary navigation into this page. */
@@ -179,6 +179,7 @@ export default function ProjectDetail({
     jobId: string;
     kind: string;
     status: string | null;
+    createdAt: string | null;
   } | null = inMemoryActiveJob
     ? {
       jobId: inMemoryActiveJob.jobId,
@@ -186,6 +187,10 @@ export default function ProjectDetail({
         status:
           serverActiveJob?.jobId === inMemoryActiveJob.jobId
             ? serverActiveJob.status
+            : null,
+        createdAt:
+          serverActiveJob?.jobId === inMemoryActiveJob.jobId
+            ? serverActiveJob.createdAt
             : null,
       }
     : serverActiveJob;
@@ -1040,6 +1045,7 @@ export default function ProjectDetail({
                               onViewActiveJob(
                                 activeJobForProject.jobId,
                                 activeJobForProject.kind,
+                                activeJobForProject.createdAt,
                               )
                             }
                             className="text-white underline hover:opacity-80 cursor-pointer"

--- a/landing-page/src/components/workflow/ProcessingPage.tsx
+++ b/landing-page/src/components/workflow/ProcessingPage.tsx
@@ -26,6 +26,7 @@ interface ProcessingPageProps {
   projectId?: number | null;
   jobKind?: string;
   initialLogsOpen?: boolean;
+  startedAtMs?: number;
 }
 
 const STAGE_LABELS = ["checking", "validating", "processing"];
@@ -68,6 +69,7 @@ export default function ProcessingPage({
   projectId,
   jobKind,
   initialLogsOpen = false,
+  startedAtMs,
 }: ProcessingPageProps) {
   const [done, setDone] = useState(false);
   const [progress, setProgress] = useState(0);
@@ -78,6 +80,8 @@ export default function ProcessingPage({
   ]);
   const [logsOpen, setLogsOpen] = useState(initialLogsOpen);
   const [cancelPrompt, setCancelPrompt] = useState(false);
+  const [cancelling, setCancelling] = useState(false);
+
   const pausedRef = useRef(false);
   const completedRef = useRef(false);
   const streamAbortRef = useRef<AbortController | null>(null);
@@ -398,7 +402,8 @@ export default function ProcessingPage({
     setRevealedLogs([]);
     setItemProgress(null);
     completedRef.current = false;
-    startTimeRef.current = Date.now();
+    startTimeRef.current =
+      startedAtMs != null && Number.isFinite(startedAtMs) ? startedAtMs : Date.now();
     estimatedTotalMsRef.current = getAverageDurationMs(jobKind ?? "unknown");
     avgItemMsRef.current = null;
     itemDurationsRef.current = [];
@@ -534,17 +539,27 @@ export default function ProcessingPage({
               <span> are you sure? </span>
               <button
                 onClick={async () => {
+                  setCancelling(true);
                   streamAbortRef.current?.abort();
                   if (jobIdRef.current) {
-                    apiFetch(`/api/jobs/${jobIdRef.current}/cancel`, {
-                      method: "POST",
-                    }).catch(() => {});
+                    const id = jobIdRef.current;
+                    markJobSettled(id);
+                    try {
+                      apiFetch(`/api/jobs/${jobIdRef.current}/cancel`, {
+                        method: "POST",
+                      });
+                    } catch {
+                      // best-effort -- still navigate back; the project page's
+                      // own poll self-corrects within 5s even if this
+                      // particular request didn't make it through
+                    }
                   }
                   onBack();
                 }}
+                disabled={cancelling}
                 className="px-3 py-1 bg-white text-[#4AADAA] rounded-lg font-semibold hover:opacity-90 cursor-pointer"
               >
-                yes
+                {cancelling ? "cancelling..." : "yes"}
               </button>
               <button
                 onClick={() => setCancelPrompt(false)}

--- a/landing-page/src/components/workflow/ProcessingPage.tsx
+++ b/landing-page/src/components/workflow/ProcessingPage.tsx
@@ -81,6 +81,7 @@ export default function ProcessingPage({
   const [logsOpen, setLogsOpen] = useState(initialLogsOpen);
   const [cancelPrompt, setCancelPrompt] = useState(false);
   const [cancelling, setCancelling] = useState(false);
+  const [cancelError, setCancelError] = useState<string | null>(null);
 
   const pausedRef = useRef(false);
   const completedRef = useRef(false);
@@ -540,24 +541,46 @@ export default function ProcessingPage({
               <button
                 onClick={async () => {
                   setCancelling(true);
+                  setCancelError(null);
                   streamAbortRef.current?.abort();
-                  if (jobIdRef.current) {
-                    const id = jobIdRef.current;
-                    markJobSettled(id);
+                  const id = jobIdRef.current;
+                  if (id) {
+                    // Awaited and validated -- an unawaited fire-and-forget
+                    // POST here meant a 404/403/409 or a network failure was
+                    // silently ignored, and the job got marked settled and
+                    // navigated away from regardless, leaving it running
+                    // server-side with no way left on this page to retry the
+                    // cancel. On failure, stay on this page (stream is
+                    // already aborted either way -- the user confirmed they
+                    // want to stop watching) and surface the error instead.
                     try {
-                      apiFetch(`/api/jobs/${jobIdRef.current}/cancel`, {
+                      const r = await apiFetch(`/api/jobs/${id}/cancel`, {
                         method: "POST",
                       });
+                      if (!r.ok) {
+                        const d = await r.json().catch(() => ({}));
+                        setCancelError(
+                          (d as { detail?: string }).detail ??
+                            `cancel failed (${r.status})`,
+                        );
+                        setCancelling(false);
+                        return;
+                      }
                     } catch {
-                      // best-effort -- still navigate back; the project page's
-                      // own poll self-corrects within 5s even if this
-                      // particular request didn't make it through
+                      setCancelError("cancel failed -- check your connection");
+                      setCancelling(false);
+                      return;
                     }
+                    markJobSettled(id);
                   }
+                  // No job id yet (kickoff hasn't gotten one from the server
+                  // -- nothing exists server-side to cancel) is the only
+                  // path that reaches here without a confirmed cancel; it's
+                  // still correct to just leave.
                   onBack();
                 }}
                 disabled={cancelling}
-                className="px-3 py-1 bg-white text-[#4AADAA] rounded-lg font-semibold hover:opacity-90 cursor-pointer"
+                className="px-3 py-1 bg-white text-[#4AADAA] rounded-lg font-semibold hover:opacity-90 cursor-pointer disabled:opacity-50"
               >
                 {cancelling ? "cancelling..." : "yes"}
               </button>
@@ -575,6 +598,9 @@ export default function ProcessingPage({
             </span>
           )}
         </div>
+        {cancelError && (
+          <p className="mt-2 text-red-200 text-sm font-mono">{cancelError}</p>
+        )}
         {streamError && !done && (
           <div className="mt-4 flex flex-col items-start gap-2">
             <p className="text-red-200 text-sm font-mono">{streamError}</p>

--- a/landing-page/src/hooks/useProjectActiveJob.ts
+++ b/landing-page/src/hooks/useProjectActiveJob.ts
@@ -5,6 +5,7 @@ export interface ProjectActiveJob {
     jobId: string;
     kind: string;
     status: string;
+    createdAt: string | null;
 }
 
 /** Polls GET /api/projects/{id}/active-job -- the server-side source of
@@ -30,11 +31,20 @@ export function useProjectActiveJob(projectId: number | null) {
             // discovered after a reload/from a different tab, with nothing
             // in the in-memory activeJobs.ts registry to fall back on) reads
             // `jobId` as undefined.
-            const data: { job_id: string; kind: string; status: string } | null =
-                await r.json();
+            const data: {
+                job_id: string;
+                kind: string;
+                status: string;
+                created_at: string | null;
+            } | null = await r.json();
             setJob(
                 data
-                    ? { jobId: data.job_id, kind: data.kind, status: data.status }
+                    ? {
+                          jobId: data.job_id,
+                          kind: data.kind,
+                          status: data.status,
+                          createdAt: data.created_at,
+                      }
                     : null,
             );
         } catch {


### PR DESCRIPTION
refs: #194, #204, #205

- long project names have line breaks now instead of being truncated and/or extending outside their container
- estimated time no longer resets if the user leaves and goes back to the processing page
- cancelling a job from the processing page gets rid of the "an x job is running" text/greyed out button on the project detail page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resumed processing jobs now retain their original start time, providing more accurate elapsed-time tracking.
  * Active job details now include creation time when available.
* **Bug Fixes**
  * Cancelling a job now immediately settles its active state, prevents duplicate confirmation, and displays a “cancelling...” status.
* **Style**
  * Project names display in full with wrapping instead of being truncated.
  * Back-button spacing is improved on responsive layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->